### PR TITLE
Docs - update the index page to correctly reference Azure Table Storage

### DIFF
--- a/docs/preview/index.md
+++ b/docs/preview/index.md
@@ -23,7 +23,7 @@ For more granular packages we recommend reading the documentation.
 * Automate Azure DevOps tasks ([powershell](features/powershell/azure-devops))
 * Automate Azure Key Vault tasks ([powershell](features/powershell/azure-key-vault))
 * Automate Azure Resource Manager (ARM) tasks ([powershell](features/powershell/arm))
-* Automate Azure Table Storage tasks ([powershell](features/powershell/azure-table-storage))
+* Automate Azure Table Storage tasks ([powershell](features/powershell/azure-storage))
 
 # License
 This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.

--- a/docs/preview/index.md
+++ b/docs/preview/index.md
@@ -23,7 +23,7 @@ For more granular packages we recommend reading the documentation.
 * Automate Azure DevOps tasks ([powershell](features/powershell/azure-devops))
 * Automate Azure Key Vault tasks ([powershell](features/powershell/azure-key-vault))
 * Automate Azure Resource Manager (ARM) tasks ([powershell](features/powershell/arm))
-* Automate Azure Table Storage tasks ([powershell](features/powershell/azure-storage))
+* Automate Azure Storage tasks ([powershell](features/powershell/azure-storage))
 
 # License
 This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.


### PR DESCRIPTION
The index was not referencing the Azure Table Storage feature docs page correctly.
This PR changes that.