### PR TITLE
Fix - use correct GitHub repository in PS Gallery release

### DIFF
--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -18,7 +18,7 @@ variables:
   - group: 'Build Configuration'
   - template: ./variables/build.yml
   - name: 'Repository'
-    value: 'arcus-azure/arcus.template'
+    value: 'arcus-azure/arcus.scripting'
   - name: 'Package.Version'
     value: ${{ parameters['Package.Version'] }}
 


### PR DESCRIPTION
Azure DevOps release pipeline YAML still was using the Arcus template value for the GitHub repository.