### PR TITLE
Fix - remove spaces from PS manifests

### DIFF
--- a/src/Arcus.Scripting.KeyVault/Arcus.Scripting.KeyVault.psd1
+++ b/src/Arcus.Scripting.KeyVault/Arcus.Scripting.KeyVault.psd1
@@ -89,7 +89,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = 'Azure', 'Security', 'Key Vault', 'Arcus'
+        Tags = 'Azure', 'Security', 'KeyVault', 'Arcus'
 
 
         # A URL to the license for this module.

--- a/src/Arcus.Scripting.Storage.Table/Arcus.Scripting.Storage.Table.psd1
+++ b/src/Arcus.Scripting.Storage.Table/Arcus.Scripting.Storage.Table.psd1
@@ -89,7 +89,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.	
-        Tags = 'Azure', 'Storage', 'Data', 'Table Storage', 'Arcus'
+        Tags = 'Azure', 'Storage', 'Data', 'TableStorage', 'Arcus'
 
         # A URL to the license for this module.
         LicenseUri = 'https://github.com/arcus-azure/arcus.scripting/blob/master/LICENSE'


### PR DESCRIPTION
Spaces are not allowed in PowerShell manifests, so remove them in all.