### PR TITLE
Feature - set subscription keys to an API in Azure API Management

### DIFF
--- a/docs/preview/features/powershell/azure-api-management.md
+++ b/docs/preview/features/powershell/azure-api-management.md
@@ -136,7 +136,7 @@ Write-Host "Subscription key header 'x-api-key' was assigned"
 Write-Host "Subscription key query parameter 'apiKey' was assigned"
 ```
 
-**Custom values**
+**User-defined values**
 
 ```powershell
 PS> Set-AzApiManagementApiSubscriptionKey -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ApiId $ApiId -ApiKeyHeaderName "my-api-key" -ApiQueryParamName "myApiKey"

--- a/docs/preview/features/powershell/azure-api-management.md
+++ b/docs/preview/features/powershell/azure-api-management.md
@@ -24,17 +24,17 @@ PS> Import-Module -Name Arcus.Scripting.ApiManagement
 
 Create an operation on an existing API in Azure API Management.
 
-| Parameter           | Mandatory | Description                                                                                              |
-| ------------------- | --------- | -------------------------------------------------------------------------------------------------------- |
-| `ResourceGroupName` | yes       | The resource group containing the Azure API Management instance                                          |
-| `ServiceName`       | yes       | The name of the Azure API Management instance located in Azure                                           |
-| `ApiId`             | yes       | The ID to identify the API running in Azure API Management                                               |
-| `OperationId`       | yes       | The ID to identify the to-be-created operation on the API                                                |
-| `Method`            | yes       | The method of the to-be-created operation on the API                                                     |
-| `UrlTemplate`       | yes       | The URL-template, or endpoint-URL, of the to-be-created operation on the API                             |
-| `OperationName`     | no        | The optional descriptive name to give to the to-be-created operation on the API (default: `OperationId`) |
-| `Description`       | no        | The optional explanation to describe the to-be-created operation on the API                              |
-| `PolicyFilePath`    | no        | The path to the file containing the optional policy of the to-be-created operation on the API            |
+| Parameter        | Mandatory | Description                                                                                              |
+| ---------------- | --------- | -------------------------------------------------------------------------------------------------------- |
+| `ResourceGroup`  | yes       | The resource group containing the Azure API Management instance                                          |
+| `ServiceName`    | yes       | The name of the Azure API Management instance located in Azure                                           |
+| `ApiId`          | yes       | The ID to identify the API running in Azure API Management                                               |
+| `OperationId`    | yes       | The ID to identify the to-be-created operation on the API                                                |
+| `Method`         | yes       | The method of the to-be-created operation on the API                                                     |
+| `UrlTemplate`    | yes       | The URL-template, or endpoint-URL, of the to-be-created operation on the API                             |
+| `OperationName`  | no        | The optional descriptive name to give to the to-be-created operation on the API (default: `OperationId`) |
+| `Description`    | no        | The optional explanation to describe the to-be-created operation on the API                              |
+| `PolicyFilePath` | no        | The path to the file containing the optional policy of the to-be-created operation on the API            |
 
 **Example**
 
@@ -56,12 +56,12 @@ PS> Create-AzApiManagementApiOperation -ResourceGroup $ResourceGroup -ServiceNam
 
 Imports a policy from a file to a product in Azure API Management.
 
-| Parameter           | Mandatory | Description                                                     |
-| ------------------- | --------- | --------------------------------------------------------------- |
-| `ResourceGroupName` | yes       | The resource group containing the Azure API Management instance |
-| `ServiceName`       | yes       | The name of the Azure API Management instance located in Azure  |
-| `ProductId`         | yes       | The ID to identify the product in Azure API Management          |
-| `PolicyFilePath`    | yes       | The path to the file containing the to-be-imported policy       |
+| Parameter        | Mandatory | Description                                                     |
+| -----------------| --------- | --------------------------------------------------------------- |
+| `ResourceGroup`  | yes       | The resource group containing the Azure API Management instance |
+| `ServiceName`    | yes       | The name of the Azure API Management instance located in Azure  |
+| `ProductId`      | yes       | The ID to identify the product in Azure API Management          |
+| `PolicyFilePath` | yes       | The path to the file containing the to-be-imported policy       |
 
 ```powershell
 PS> Import-AzApiManagementProductPolicy -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ProductId $ProductId -PolicyFilePath $PolicyFilePath
@@ -72,12 +72,12 @@ PS> Import-AzApiManagementProductPolicy -ResourceGroup $ResourceGroup -ServiceNa
 
 Imports a base-policy from a file to an API in Azure API Management.
 
-| Parameter           | Mandatory | Description                                                      |
-| ------------------- | --------- | ---------------------------------------------------------------- |
-| `ResourceGroupName` | yes       | The resource group containing the Azure API Management instance  |
-| `ServiceName`       | yes       | The name of the Azure API Management instance located in Azure   |
-| `ApiId`             | yes       | The ID to identify the API running in Azure API Management       |
-| `PolicyFilePath`    | yes       | The path to the file containing the to-be-imported policy        |
+| Parameter        | Mandatory | Description                                                      |
+| ---------------- | --------- | ---------------------------------------------------------------- |
+| `ResourceGroup`  | yes       | The resource group containing the Azure API Management instance  |
+| `ServiceName`    | yes       | The name of the Azure API Management instance located in Azure   |
+| `ApiId`          | yes       | The ID to identify the API running in Azure API Management       |
+| `PolicyFilePath` | yes       | The path to the file containing the to-be-imported policy        |
 
 ```powershell
 PS> Import-AzApiManagementApiPolicy -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ApiId $ApiId -PolicyFilePath $PolicyFilePath
@@ -87,13 +87,13 @@ PS> Import-AzApiManagementApiPolicy -ResourceGroup $ResourceGroup -ServiceName $
 ## Importing a policy to an operation in the Azure API Management instance
 Imports a policy from a file to an API operation in Azure API Management.
 
-| Parameter           | Mandatory | Description                                                     |
-| ------------------- | --------- | --------------------------------------------------------------- |
-| `ResourceGroupName` | yes       | The resource group containing the Azure API Management instance |
-| `ServiceName`       | yes       | The name of the Azure API Management service located in Azure   |
-| `ApiId`             | yes       | The ID to identify the API running in Azure API Management      |
-| `OperationId`       | yes       | The ID to identify the operation for which to import the policy |
-| `PolicyFilePath`    | yes       | The path to the file containing the to-be-imported policy       |   
+| Parameter        | Mandatory | Description                                                     |
+| ---------------- | --------- | --------------------------------------------------------------- |
+| `ResourceGroup`  | yes       | The resource group containing the Azure API Management instance |
+| `ServiceName`    | yes       | The name of the Azure API Management service located in Azure   |
+| `ApiId`          | yes       | The ID to identify the API running in Azure API Management      |
+| `OperationId`    | yes       | The ID to identify the operation for which to import the policy |
+| `PolicyFilePath` | yes       | The path to the file containing the to-be-imported policy       |   
 
 ```powershell
 PS> Import-AzApiManagementOperationPolicy -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ApiId $ApiId -OperationId $OperationId -PolicyFilePath $PolicyFilePath
@@ -114,4 +114,33 @@ PS> Remove-AzApiManagementDefaults -ResourceGroup $ResourceGroup -ServiceName $S
 # Removing Echo Api...
 # Removing Starter product...
 # Removing Unlimited product...
+```
+
+## Setting authentication keys to an API in the Azure API Management instance
+Sets the subscription header/query paramenter name to an API in Azure API Management.
+
+| Parameter           | Mandatory | Description                                                                                   |
+| ------------------- | --------- | --------------------------------------------------------------------------------------------- |
+| `ResourceGroup`     | yes       | The resource group containing the Azure API Management instance                               |
+| `ServiceName`       | yes       | The name of the Azure API Management instance located in Azure                                |
+| `ApiId`             | yes       | The ID to identify the API running in Azure API Management                                    |
+| `ApiKeyHeaderName`  | no        | The name of the header where the subscription key should be set. (default: `x-api-key`)       |
+| `ApiQueryParamName` | no        | The name of the query parameter where the subscription key should be set. (default: `apiKey`) |
+
+** Using default**
+
+```powershell
+PS> Set-AzApiManagementApiSubscriptionKey -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ApiId $ApiId
+Write-Host "Using API Management instance '$ServiceName' in resource group '$ResourceGroup'"
+Write-Host "Subscription key header 'x-api-key' was assigned"
+Write-Host "Subscription key query parameter 'apiKey' was assigned"
+```
+
+**Custom values**
+
+```powershell
+PS> Set-AzApiManagementApiSubscriptionKey -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ApiId $ApiId -ApiKeyHeaderName "my-api-key" -ApiQueryParamName "myApiKey"
+Write-Host "Using API Management instance '$ServiceName' in resource group '$ResourceGroup'"
+Write-Host "Subscription key header 'my-api-key' was assigned"
+Write-Host "Subscription key query parameter 'myApiKey' was assigned"
 ```

--- a/docs/preview/features/powershell/azure-api-management.md
+++ b/docs/preview/features/powershell/azure-api-management.md
@@ -119,13 +119,13 @@ PS> Remove-AzApiManagementDefaults -ResourceGroup $ResourceGroup -ServiceName $S
 ## Setting authentication keys to an API in the Azure API Management instance
 Sets the subscription header/query paramenter name to an API in Azure API Management.
 
-| Parameter           | Mandatory | Description                                                                                   |
-| ------------------- | --------- | --------------------------------------------------------------------------------------------- |
-| `ResourceGroup`     | yes       | The resource group containing the Azure API Management instance                               |
-| `ServiceName`       | yes       | The name of the Azure API Management instance located in Azure                                |
-| `ApiId`             | yes       | The ID to identify the API running in Azure API Management                                    |
-| `ApiKeyHeaderName`  | no        | The name of the header where the subscription key should be set. (default: `x-api-key`)       |
-| `ApiQueryParamName` | no        | The name of the query parameter where the subscription key should be set. (default: `apiKey`) |
+| Parameter        | Mandatory | Description                                                                                   |
+| ---------------- | --------- | --------------------------------------------------------------------------------------------- |
+| `ResourceGroup`  | yes       | The resource group containing the Azure API Management instance                               |
+| `ServiceName`    | yes       | The name of the Azure API Management instance located in Azure                                |
+| `ApiId`          | yes       | The ID to identify the API running in Azure API Management                                    |
+| `HeaderName`     | no        | The name of the header where the subscription key should be set. (default: `x-api-key`)       |
+| `QueryParamName` | no        | The name of the query parameter where the subscription key should be set. (default: `apiKey`) |
 
 **Using default**
 
@@ -139,7 +139,7 @@ Write-Host "Subscription key query parameter 'apiKey' was assigned"
 **User-defined values**
 
 ```powershell
-PS> Set-AzApiManagementApiSubscriptionKey -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ApiId $ApiId -ApiKeyHeaderName "my-api-key" -ApiQueryParamName "myApiKey"
+PS> Set-AzApiManagementApiSubscriptionKey -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ApiId $ApiId -HeaderName "my-api-key" -QueryParamName "myApiKey"
 Write-Host "Using API Management instance '$ServiceName' in resource group '$ResourceGroup'"
 Write-Host "Subscription key header 'my-api-key' was assigned"
 Write-Host "Subscription key query parameter 'myApiKey' was assigned"

--- a/docs/preview/features/powershell/azure-api-management.md
+++ b/docs/preview/features/powershell/azure-api-management.md
@@ -127,7 +127,7 @@ Sets the subscription header/query paramenter name to an API in Azure API Manage
 | `ApiKeyHeaderName`  | no        | The name of the header where the subscription key should be set. (default: `x-api-key`)       |
 | `ApiQueryParamName` | no        | The name of the query parameter where the subscription key should be set. (default: `apiKey`) |
 
-** Using default**
+**Using default**
 
 ```powershell
 PS> Set-AzApiManagementApiSubscriptionKey -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ApiId $ApiId

--- a/src/Arcus.Scripting.ApiManagement/Arcus.Scripting.ApiManagement.psd1
+++ b/src/Arcus.Scripting.ApiManagement/Arcus.Scripting.ApiManagement.psd1
@@ -66,7 +66,13 @@ RequiredModules = @(@{ModuleName='Az.ApiManagement'; ModuleVersion='2.0.0'})
 # NestedModules = @()
 
 # Functions to export from this module
-FunctionsToExport = @('Create-AzApiManagementApiOperation', 'Remove-AzApiManagementDefaults', 'Import-AzApiManagementProductPolicy', 'Import-AzApiManagementApiPolicy', 'Import-AzApiManagementOperationPolicy')
+FunctionsToExport = @(
+    'Create-AzApiManagementApiOperation', 
+    'Remove-AzApiManagementDefaults', 
+    'Import-AzApiManagementProductPolicy', 
+    'Import-AzApiManagementApiPolicy', 
+    'Import-AzApiManagementOperationPolicy',
+    'Set-AzApiManagementApiSubscriptionKey')
 
 # Cmdlets to export from this module
 CmdletsToExport = '*'

--- a/src/Arcus.Scripting.ApiManagement/Arcus.Scripting.ApiManagement.psm1
+++ b/src/Arcus.Scripting.ApiManagement/Arcus.Scripting.ApiManagement.psm1
@@ -190,10 +190,10 @@ function Import-AzApiManagementOperationPolicy {
  .Parameter ApiId
   The ID to identify the API running in Azure API Management.
 
- .Parameter ApiKeyHeaderName
+ .Parameter KeyHeaderName
   The name of the header where the subscription key should be set.
 
- .Parameter ApiQueryParamName
+ .Parameter QueryParamName
   The name of the query parameter where the subscription key should be set.
 #>
 function Set-AzApiManagementApiSubscriptionKey {
@@ -201,9 +201,9 @@ function Set-AzApiManagementApiSubscriptionKey {
         [Parameter(Mandatory = $true)][string] $ResourceGroup,
         [Parameter(Mandatory = $true)][string] $ServiceName,
         [Parameter(Mandatory = $true)][string] $ApiId,
-        [Parameter(Mandatory = $false)][string] $ApiKeyHeaderName = "x-api-key",
-        [Parameter(Mandatory = $false)][string] $ApiQueryParamName = "apiKey"
+        [Parameter(Mandatory = $false)][string] $HeaderName = "x-api-key",
+        [Parameter(Mandatory = $false)][string] $QueryParamName = "apiKey"
     )
 
-    . $PSScriptRoot\Scripts\Set-AzApiManagementApiSubscriptionKey.ps1 -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ApiId $ApiId -ApiKeyHeaderName $ApiKeyHeaderName -ApiQueryParamName $ApiQueryParamName
+    . $PSScriptRoot\Scripts\Set-AzApiManagementApiSubscriptionKey.ps1 -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ApiId $ApiId -KeyHeaderName $KeyHeaderName -QueryParamName $QueryParamName
 }

--- a/src/Arcus.Scripting.ApiManagement/Arcus.Scripting.ApiManagement.psm1
+++ b/src/Arcus.Scripting.ApiManagement/Arcus.Scripting.ApiManagement.psm1
@@ -173,3 +173,37 @@ function Import-AzApiManagementOperationPolicy {
 
     . $PSScriptRoot\Scripts\Import-AzApiManagementOperationPolicy.ps1 -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ApiId $ApiId -OperationId $OperationId -PolicyFilePath $PolicyFilePath
 }
+
+<#
+ .Synopsis
+  Sets the authentication keys in Azure API Management.
+
+ .Description
+  Sets the authentication header/query parameter on an API in Azure API Management.
+
+ .Parameter ResourceGroup
+  The resource group containing the Azure API Management instance.
+
+ .Parameter ServiceName
+  The name of the Azure API Management instance located in Azure.
+  
+ .Parameter ApiId
+  The ID to identify the API running in Azure API Management.
+
+ .Parameter ApiKeyHeaderName
+  The name of the header where the subscription key should be set.
+
+ .Parameter ApiQueryParamName
+  The name of the query parameter where the subscription key should be set.
+#>
+function Set-AzApiManagementApiSubscriptionKey {
+    param(
+        [Parameter(Mandatory = $true)][string] $ResourceGroup,
+        [Parameter(Mandatory = $true)][string] $ServiceName,
+        [Parameter(Mandatory = $true)][string] $ApiId,
+        [Parameter(Mandatory = $false)][string] $ApiKeyHeaderName = "x-api-key",
+        [Parameter(Mandatory = $false)][string] $ApiQueryParamName = "apiKey"
+    )
+
+    . $PSScriptRoot\Scripts\Set-AzApiManagementApiSubscriptionKey.ps1 -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ApiId $ApiId -ApiKeyHeaderName $ApiKeyHeaderName -ApiQueryParamName $ApiQueryParamName
+}

--- a/src/Arcus.Scripting.ApiManagement/Arcus.Scripting.ApiManagement.psm1
+++ b/src/Arcus.Scripting.ApiManagement/Arcus.Scripting.ApiManagement.psm1
@@ -205,5 +205,5 @@ function Set-AzApiManagementApiSubscriptionKey {
         [Parameter(Mandatory = $false)][string] $QueryParamName = "apiKey"
     )
 
-    . $PSScriptRoot\Scripts\Set-AzApiManagementApiSubscriptionKey.ps1 -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ApiId $ApiId -KeyHeaderName $KeyHeaderName -QueryParamName $QueryParamName
+    . $PSScriptRoot\Scripts\Set-AzApiManagementApiSubscriptionKey.ps1 -ResourceGroup $ResourceGroup -ServiceName $ServiceName -ApiId $ApiId -HeaderName $HeaderName -QueryParamName $QueryParamName
 }

--- a/src/Arcus.Scripting.ApiManagement/Arcus.Scripting.ApiManagement.pssproj
+++ b/src/Arcus.Scripting.ApiManagement/Arcus.Scripting.ApiManagement.pssproj
@@ -36,6 +36,7 @@
     <Compile Include="Scripts\Remove-AzApiManagementDefaults.ps1" />
     <Compile Include="Scripts\Import-AzApiManagementApiPolicy.ps1" />
     <Compile Include="Scripts\Import-AzApiManagementOperationPolicy.ps1" />
+    <Compile Include="Scripts\Set-AzApiManagementApiSubscriptionKey.ps1" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="Build" />

--- a/src/Arcus.Scripting.ApiManagement/Scripts/Set-AzApiManagementApiSubscriptionKey.ps1
+++ b/src/Arcus.Scripting.ApiManagement/Scripts/Set-AzApiManagementApiSubscriptionKey.ps1
@@ -2,13 +2,13 @@ param(
     [Parameter(Mandatory = $true)][string] $ResourceGroup,
     [Parameter(Mandatory = $true)][string] $ServiceName,
     [Parameter(Mandatory = $true)][string] $ApiId,
-    [Parameter(Mandatory = $false)][string] $ApiKeyHeaderName = "x-api-key",
-    [Parameter(Mandatory = $false)][string] $ApiQueryParamName = "apiKey"
+    [Parameter(Mandatory = $false)][string] $KeyHeaderName = "x-api-key",
+    [Parameter(Mandatory = $false)][string] $QueryParamName = "apiKey"
 )
 
 $apimContext = New-AzApiManagementContext -ResourceGroupName $ResourceGroup -ServiceName $ServiceName
 Write-Host "Using API Management instance '$ServiceName' in resource group '$ResourceGroup'"
 
-Set-AzApiManagementApi -Context $apimContext -ApiId $ApiId -Protocols "https" -SubscriptionKeyHeaderName $ApiKeyHeaderName -SubscriptionKeyQueryParamName $ApiQueryParamName
-Write-Host "Subscription key header '$ApiKeyHeaderName' was assigned"
-Write-Host "Subscription key query parameter '$ApiQueryParamName' was assigned"
+Set-AzApiManagementApi -Context $apimContext -ApiId $ApiId -Protocols "https" -SubscriptionKeyHeaderName $KeyHeaderName -SubscriptionKeyQueryParamName $QueryParamName
+Write-Host "Subscription key header '$KeyHeaderName' was assigned"
+Write-Host "Subscription key query parameter '$QueryParamName' was assigned"

--- a/src/Arcus.Scripting.ApiManagement/Scripts/Set-AzApiManagementApiSubscriptionKey.ps1
+++ b/src/Arcus.Scripting.ApiManagement/Scripts/Set-AzApiManagementApiSubscriptionKey.ps1
@@ -9,6 +9,6 @@ param(
 $apimContext = New-AzApiManagementContext -ResourceGroupName $ResourceGroup -ServiceName $ServiceName
 Write-Host "Using API Management instance '$ServiceName' in resource group '$ResourceGroup'"
 
-Set-AzApiManagementApi -Context $apimContext -ApiId $ApiId -Protocols "https" -SubscriptionKeyHeaderName $KeyHeaderName -SubscriptionKeyQueryParamName $QueryParamName
+Set-AzApiManagementApi -Context $apimContext -ApiId $ApiId -SubscriptionKeyHeaderName $KeyHeaderName -SubscriptionKeyQueryParamName $QueryParamName
 Write-Host "Subscription key header '$KeyHeaderName' was assigned"
 Write-Host "Subscription key query parameter '$QueryParamName' was assigned"

--- a/src/Arcus.Scripting.ApiManagement/Scripts/Set-AzApiManagementApiSubscriptionKey.ps1
+++ b/src/Arcus.Scripting.ApiManagement/Scripts/Set-AzApiManagementApiSubscriptionKey.ps1
@@ -2,13 +2,13 @@ param(
     [Parameter(Mandatory = $true)][string] $ResourceGroup,
     [Parameter(Mandatory = $true)][string] $ServiceName,
     [Parameter(Mandatory = $true)][string] $ApiId,
-    [Parameter(Mandatory = $false)][string] $KeyHeaderName = "x-api-key",
+    [Parameter(Mandatory = $false)][string] $HeaderName = "x-api-key",
     [Parameter(Mandatory = $false)][string] $QueryParamName = "apiKey"
 )
 
 $apimContext = New-AzApiManagementContext -ResourceGroupName $ResourceGroup -ServiceName $ServiceName
 Write-Host "Using API Management instance '$ServiceName' in resource group '$ResourceGroup'"
 
-Set-AzApiManagementApi -Context $apimContext -ApiId $ApiId -SubscriptionKeyHeaderName $KeyHeaderName -SubscriptionKeyQueryParamName $QueryParamName
-Write-Host "Subscription key header '$KeyHeaderName' was assigned"
+Set-AzApiManagementApi -Context $apimContext -ApiId $ApiId -SubscriptionKeyHeaderName $HeaderName -SubscriptionKeyQueryParamName $QueryParamName
+Write-Host "Subscription key header '$HeaderName' was assigned"
 Write-Host "Subscription key query parameter '$QueryParamName' was assigned"

--- a/src/Arcus.Scripting.ApiManagement/Scripts/Set-AzApiManagementApiSubscriptionKey.ps1
+++ b/src/Arcus.Scripting.ApiManagement/Scripts/Set-AzApiManagementApiSubscriptionKey.ps1
@@ -1,0 +1,14 @@
+param(
+    [Parameter(Mandatory = $true)][string] $ResourceGroup,
+    [Parameter(Mandatory = $true)][string] $ServiceName,
+    [Parameter(Mandatory = $true)][string] $ApiId,
+    [Parameter(Mandatory = $false)][string] $ApiKeyHeaderName = "x-api-key",
+    [Parameter(Mandatory = $false)][string] $ApiQueryParamName = "apiKey"
+)
+
+$apimContext = New-AzApiManagementContext -ResourceGroupName $ResourceGroup -ServiceName $ServiceName
+Write-Host "Using API Management instance '$ServiceName' in resource group '$ResourceGroup'"
+
+Set-AzApiManagementApi -Context $apimContext -ApiId $ApiId -Protocols "https" -SubscriptionKeyHeaderName $ApiKeyHeaderName -SubscriptionKeyQueryParamName $ApiQueryParamName
+Write-Host "Subscription key header '$ApiKeyHeaderName' was assigned"
+Write-Host "Subscription key query parameter '$ApiQueryParamName' was assigned"

--- a/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.ApiManagement.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.ApiManagement.tests.ps1
@@ -341,6 +341,32 @@ Describe "Arcus" {
                 # Assert
                 Assert-VerifiableMock
             }
+            It "Sets subscription keys on an API in Azure API Management" {
+                # Arrange
+                $resourceGroup = "shopping"
+                $serviceName = "shopping-API-management"
+                $apiId = "shopping-API"
+                $apiKeyHeaderName = "header-name"
+                $apiKeyQueryParamName = "query-param-name"
+                $context = New-Object -TypeName Microsoft.Azure.Commands.ApiManagement.ServiceManagement.Models.PsApiManagementContext
+
+                Mock New-AzApiManagementContext {
+                    $ResourceGroup | Should -Be $resourceGroup
+                    $ServiceName | Should -Be $serviceName
+                    return $context } -Verifiable
+
+                Mock Set-AzApiManagementApi {
+                    $Context | Should -be $context
+                    $ApiId | Should -Be $apiId
+                    $SubscriptionKeyHeaderName | Should -Be $apiKeyHeaderName
+                    $SubscriptionKeyQueryParamName | Should -Be $apiKeyQueryParamName } -Verifiable
+
+                # Act
+                Set-AzApiManagementApiSubscriptionKey -ResourceGroup $resourceGroup -ServiceName $serviceName -ApiId $apiId -ApiKeyHeaderName $apiKeyHeaderName -ApiQueryParamName $apiKeyQueryParamName
+
+                # Assert
+                Assert-VerifiableMock
+            }
         }
     }
 }

--- a/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.ApiManagement.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.ApiManagement.tests.ps1
@@ -362,7 +362,7 @@ Describe "Arcus" {
                     $SubscriptionKeyQueryParamName | Should -Be $apiKeyQueryParamName } -Verifiable
 
                 # Act
-                Set-AzApiManagementApiSubscriptionKey -ResourceGroup $resourceGroup -ServiceName $serviceName -ApiId $apiId -ApiKeyHeaderName $apiKeyHeaderName -ApiQueryParamName $apiKeyQueryParamName
+                Set-AzApiManagementApiSubscriptionKey -ResourceGroup $resourceGroup -ServiceName $serviceName -ApiId $apiId -KeyHeaderName $apiKeyHeaderName -QueryParamName $apiKeyQueryParamName
 
                 # Assert
                 Assert-VerifiableMock

--- a/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.ApiManagement.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.ApiManagement.tests.ps1
@@ -362,7 +362,7 @@ Describe "Arcus" {
                     $SubscriptionKeyQueryParamName | Should -Be $apiKeyQueryParamName } -Verifiable
 
                 # Act
-                Set-AzApiManagementApiSubscriptionKey -ResourceGroup $resourceGroup -ServiceName $serviceName -ApiId $apiId -KeyHeaderName $apiKeyHeaderName -QueryParamName $apiKeyQueryParamName
+                Set-AzApiManagementApiSubscriptionKey -ResourceGroup $resourceGroup -ServiceName $serviceName -ApiId $apiId -HeaderName $apiKeyHeaderName -QueryParamName $apiKeyQueryParamName
 
                 # Assert
                 Assert-VerifiableMock


### PR DESCRIPTION
Provides script on API Management PS module that sets the subscription header and query parameter to an API running on API Management.

Closes #39 