### PR TITLE
Use `Install-Module` instead of `Import-Module`

### DIFF
--- a/docs/features/powershell/arm.md
+++ b/docs/features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.ARM
+PS> Install-Module -Name Arcus.Scripting.ARM
 ```
 
 ## Injecting content into an ARM template

--- a/docs/features/powershell/azure-api-management.md
+++ b/docs/features/powershell/azure-api-management.md
@@ -17,7 +17,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.ApiManagement
+PS> Install-Module -Name Arcus.Scripting.ApiManagement
 ```
 
 ## Creating a new API operation in the Azure API Management instance

--- a/docs/features/powershell/azure-data-factory.md
+++ b/docs/features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.DataFactory
+PS> Install-Module -Name Arcus.Scripting.DataFactory
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/features/powershell/azure-devops.md
+++ b/docs/features/powershell/azure-devops.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.DevOps
+PS> Install-Module -Name Arcus.Scripting.DevOps
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/features/powershell/azure-key-vault.md
+++ b/docs/features/powershell/azure-key-vault.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.KeyVault
+PS> Install-Module -Name Arcus.Scripting.KeyVault
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/features/powershell/azure-storage.md
+++ b/docs/features/powershell/azure-storage.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Storage.Table
+PS> Install-Module -Name Arcus.Scripting.Storage.Table
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/preview/features/powershell/arm.md
+++ b/docs/preview/features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.ARM
+PS> Install-Module -Name Arcus.Scripting.ARM
 ```
 
 ## Injecting content into an ARM template

--- a/docs/preview/features/powershell/azure-api-management.md
+++ b/docs/preview/features/powershell/azure-api-management.md
@@ -18,7 +18,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.ApiManagement
+PS> Install-Module -Name Arcus.Scripting.ApiManagement
 ```
 
 ## Backing up an API Management service

--- a/docs/preview/features/powershell/azure-data-factory.md
+++ b/docs/preview/features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.DataFactory
+PS> Install-Module -Name Arcus.Scripting.DataFactory
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/preview/features/powershell/azure-devops.md
+++ b/docs/preview/features/powershell/azure-devops.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.DevOps
+PS> Install-Module -Name Arcus.Scripting.DevOps
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/preview/features/powershell/azure-key-vault.md
+++ b/docs/preview/features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.KeyVault
+PS> Install-Module -Name Arcus.Scripting.KeyVault
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/preview/features/powershell/azure-logic-apps.md
+++ b/docs/preview/features/powershell/azure-logic-apps.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.LogicApps
+PS> Install-Module -Name Arcus.Scripting.LogicApps
 ```
 
 ## Disabling Azure Logic Apps from configuration file

--- a/docs/preview/features/powershell/azure-storage.md
+++ b/docs/preview/features/powershell/azure-storage.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Storage.Table
+PS> Install-Module -Name Arcus.Scripting.Storage.Table
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/v0.1.3/features/powershell/arm.md
+++ b/docs/v0.1.3/features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.ARM
+PS> Install-Module -Name Arcus.Scripting.ARM
 ```
 
 ## Injecting content into an ARM template

--- a/docs/v0.1.3/features/powershell/azure-api-management.md
+++ b/docs/v0.1.3/features/powershell/azure-api-management.md
@@ -17,7 +17,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.ApiManagement
+PS> Install-Module -Name Arcus.Scripting.ApiManagement
 ```
 
 ## Creating a new API operation in the Azure API Management instance

--- a/docs/v0.1.3/features/powershell/azure-data-factory.md
+++ b/docs/v0.1.3/features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.DataFactory
+PS> Install-Module -Name Arcus.Scripting.DataFactory
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/v0.1.3/features/powershell/azure-devops.md
+++ b/docs/v0.1.3/features/powershell/azure-devops.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.DevOps
+PS> Install-Module -Name Arcus.Scripting.DevOps
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/v0.1.3/features/powershell/azure-key-vault.md
+++ b/docs/v0.1.3/features/powershell/azure-key-vault.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.KeyVault
+PS> Install-Module -Name Arcus.Scripting.KeyVault
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/v0.1.3/features/powershell/azure-storage.md
+++ b/docs/v0.1.3/features/powershell/azure-storage.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Storage.Table
+PS> Install-Module -Name Arcus.Scripting.Storage.Table
 ```
 
 ## Creating a new table in an Azure Storage Account


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

Use `Install-Module` instead of `Import-Module` because Import only works when you've installed it first