### PR TITLE
Chore - validate PowerShell module manifest during CI build

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -123,7 +123,14 @@ stages:
               path: '$(Build.SourcesDirectory)'
           - powershell: |
               Get-ChildItem -Path ./src -Filter *.psd1 -Recurse |
-                % { Write-Host "Validate PowerShell module '$($_.FullName)'"
+                % { $data = Import-PowerShellDataFile $_.FullName
+                    $requiredModules = $data.RequiredModules.ModuleName
+                    if ($requiredModules) {
+                        $requiredModules |
+                          where { $_ -notlike "Arcus.Scripting.*" } |
+                          % { Install-Module $_ -Force - SkipPublisherCheck }
+                    }
+                    Write-Host "Validate PowerShell module '$($_.FullName)'"
                     Test-ModuleManifest -Path $_.FullName }
             displayName: 'Validate PS module'
           - powershell: |

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -128,7 +128,7 @@ stages:
                     if ($requiredModules) {
                         $requiredModules |
                           where { $_ -notlike "Arcus.Scripting.*" } |
-                          % { Install-Module $_ -Force - SkipPublisherCheck }
+                          % { Install-Module $_ -Force -SkipPublisherCheck }
                     }
                     Write-Host "Validate PowerShell module '$($_.FullName)'"
                     Test-ModuleManifest -Path $_.FullName }

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -122,6 +122,11 @@ stages:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
           - powershell: |
+              Get-ChildItem -Path ./src -Filter *.psd1 -Recurse |
+                % { Write-Host "Validate PowerShell module '$($_.FullName)'"
+                    Test-ModuleManifest -Path $_.FullName }
+            displayName: 'Validate PS module'
+          - powershell: |
               Import-Module PowerShellGet -Force
               $PSGalleryPublishUri = 'https://www.myget.org/F/arcus/api/v2/package'
               $PSGallerySourceUri = 'https://www.myget.org/F/arcus/api/v2'

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -123,15 +123,17 @@ stages:
               path: '$(Build.SourcesDirectory)'
           - powershell: |
               Get-ChildItem -Path ./src -Filter *.psd1 -Recurse |
-                % { $data = Import-PowerShellDataFile $_.FullName
-                    $requiredModules = $data.RequiredModules.ModuleName
-                    if ($requiredModules) {
-                        $requiredModules |
-                          where { $_ -notlike "Arcus.Scripting.*" } |
-                          % { Install-Module $_ -Force -SkipPublisherCheck }
-                    }
+                % { 
+                  $content = Get-Content $_.FullName
+                  $content -replace "^RequiredModules", "#RequiredModules" | Out-File $_.FullName
+                  try {
                     Write-Host "Validate PowerShell module '$($_.FullName)'"
-                    Test-ModuleManifest -Path $_.FullName }
+                    Test-ModuleManifest -Path $_.FullName
+                  } finally {
+                    $content = Get-Content $_.FullName
+                    $content -replace "^#RequiredModules = @\(@", "RequiredModules = @(@" | Out-File $_.FullName
+                  } 
+                }
             displayName: 'Validate PS module'
           - powershell: |
               Import-Module PowerShellGet -Force


### PR DESCRIPTION
Validation of all the Arcus PowerShell modules during the CI build pipeline.

Closes #126 