### PR TITLE
Fix - push PS modules with `RequiredModules` to MyGet

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -121,14 +121,14 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-           - powershell: |
+          - powershell: |
               Import-Module PowerShellGet -Force
               Get-ChildItem -Path ./src -Filter *.psd1 -Recurse |
                 % { & $env:SCRIPT_PATH -ManifestPath $_.FullName -DestinationFolder $_.DirectoryName }
             displayName: 'Generate .nuspec file for each PowerShell module'
             env:
               SCRIPT_PATH: '$(Build.SourcesDirectory)\build\tools\psd1-to-nuspec.ps1'
-           - task: NuGetCommand@2
+          - task: NuGetCommand@2
             inputs:
               command: 'pack'
               packagesToPack: '**/*.nuspec'

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -121,15 +121,25 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - powershell: |
+           - powershell: |
               Import-Module PowerShellGet -Force
-              $PSGalleryPublishUri = 'https://www.myget.org/F/arcus/api/v2/package'
-              $PSGallerySourceUri = 'https://www.myget.org/F/arcus/api/v2'
-
-              Register-PSRepository -Name MyGetFeed -SourceLocation $PSGallerySourceUri -PublishLocation $PSGalleryPublishUri
-
-              Get-ChildItem -Path ./src -Filter *.psm1 -Recurse |
-                  % { Publish-Module -Path $_.DirectoryName -NuGetApiKey $env:APIKEY -Repository MyGetFeed -Verbose -Force }
-            displayName: 'Publish PS module to MyGet'
+              Get-ChildItem -Path ./src -Filter *.psd1 -Recurse |
+                % { & $env:SCRIPT_PATH -ManifestPath $_.FullName -DestinationFolder $_.DirectoryName }
+            displayName: 'Generate .nuspec file for each PowerShell module'
             env:
-              ApiKey: $(MyGet.ApiKey)
+              SCRIPT_PATH: '$(Build.SourcesDirectory)\build\tools\psd1-to-nuspec.ps1'
+           - task: NuGetCommand@2
+            inputs:
+              command: 'pack'
+              packagesToPack: '**/*.nuspec'
+              packDestination: '$(Build.ArtifactStagingDirectory)'
+          - task: NuGetToolInstaller@1
+            displayName: 'Install NuGet'
+          - powershell: |
+              $PSGalleryPublishUri = 'https://www.myget.org/F/arcus/api/v2/package'
+              Get-ChildItem -Path $env:ARTIFACT_DIR -Filter *.nupkg -Recurse |
+                  % { & "nuget" push $_.FullName -Source $PSGalleryPublishUri -ApiKey $env:APIKEY }
+            displayName: 'Push to MyGet'
+            env:
+              ARTIFACT_DIR: '$(Build.ArtifactStagingDirectory)'
+              APIKEY: $(MyGet.ApiKey)


### PR DESCRIPTION
Publish PS modules with the low-level `nuget` CLI commands so we can skip the `RequiredModules` validation which is not correct in this context. An extra module manifest syntax validation is happening (#127).

Closes #128 