### PR TITLE
PR: Fix typo in URL to new docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ For more granular packages we recommend reading the documentation.
 * Automate Azure Logic Apps tasks ([powershell](features/powershell/azure-logic-apps))
 * Automate Azure Resource Manager (ARM) tasks ([powershell](features/powershell/arm))
 * Automate Azure Security tasks ([powershell](features/powershell/azure-security))
-* Automate Azure SQL tasks ([powershell](featues/powershell/azure-sql))
+* Automate Azure SQL tasks ([powershell](features/powershell/azure-sql))
 * Automate Azure Storage tasks ([powershell](features/powershell/azure-storage))
     * Azure Table Storage tasks ([powershell](features/powershell/azure-storage-table))
     * Azure Blob Storage tasks ([powershell](features/powershell/azure-storage-blob))

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ For more granular packages we recommend reading the documentation.
 * Automate Azure Resource Manager (ARM) tasks ([powershell](features/powershell/arm))
 * Automate Azure Security tasks ([powershell](features/powershell/azure-security))
 * Automate Azure SQL tasks ([powershell](features/powershell/azure-sql))
-* Automate Azure Storage tasks ([powershell](features/powershell/azure-storage))
+* Automate Azure Storage tasks ([powershell](features/powershell/azure-storage-all))
     * Azure Table Storage tasks ([powershell](features/powershell/azure-storage-table))
     * Azure Blob Storage tasks ([powershell](features/powershell/azure-storage-blob))
     * Azure File Share Storage tasks ([powershell](features/powershell/azure-storage-fileshare))

--- a/docs/v0.4/index.md
+++ b/docs/v0.4/index.md
@@ -25,7 +25,7 @@ For more granular packages we recommend reading the documentation.
 * Automate Azure Logic Apps tasks ([powershell](features/powershell/azure-logic-apps))
 * Automate Azure Resource Manager (ARM) tasks ([powershell](features/powershell/arm))
 * Automate Azure Security tasks ([powershell](features/powershell/azure-security))
-* Automate Azure SQL tasks ([powershell](featues/powershell/azure-sql))
+* Automate Azure SQL tasks ([powershell](features/powershell/azure-sql))
 * Automate Azure Storage tasks ([powershell](features/powershell/azure-storage))
     * Azure Table Storage tasks ([powershell](features/powershell/azure-storage-table))
     * Azure Blob Storage tasks ([powershell](features/powershell/azure-storage-blob))

--- a/docs/v0.4/index.md
+++ b/docs/v0.4/index.md
@@ -26,7 +26,7 @@ For more granular packages we recommend reading the documentation.
 * Automate Azure Resource Manager (ARM) tasks ([powershell](features/powershell/arm))
 * Automate Azure Security tasks ([powershell](features/powershell/azure-security))
 * Automate Azure SQL tasks ([powershell](features/powershell/azure-sql))
-* Automate Azure Storage tasks ([powershell](features/powershell/azure-storage))
+* Automate Azure Storage tasks ([powershell](features/powershell/azure-storage-all))
     * Azure Table Storage tasks ([powershell](features/powershell/azure-storage-table))
     * Azure Blob Storage tasks ([powershell](features/powershell/azure-storage-blob))
     * Azure File Share Storage tasks ([powershell](features/powershell/azure-storage-fileshare))


### PR DESCRIPTION
Some URL contained a typo, which caused a broken link towards the pages for:
- Arcus.Scripting.Sql
- Arcus.Storage.All