### PR TITLE
fix: incorrect parameter in new role assignment security docs

### DIFF
--- a/docs/features/powershell/azure-security.md
+++ b/docs/features/powershell/azure-security.md
@@ -97,7 +97,7 @@ This function allows you to assign an Azure built-in role to a resource upon a r
 **Usage**
 
 ```powershell
-PS> New-AzResourceGroupRoleAssignment -TargetResourceGroupName "to-gain-access-resource-group" -ResourceGroupName "to-assign-role-resource-group" -ResourceName "to-assign-resource" -RoleAssignmentDefinition "Contributer"
+PS> New-AzResourceGroupRoleAssignment -TargetResourceGroupName "to-gain-access-resource-group" -ResourceGroupName "to-assign-role-resource-group" -ResourceName "to-assign-resource" -RoleDefinitionName "Contributer"
 # Assigning Contributer-rights to the 'to-assign-role-resource' in the resource group 'to-assign-resource-group to gain access to the 'to-gain-access-resource-group'
 # Contributer access granted!
 ```


### PR DESCRIPTION
Fixes the securitty docs where it uses the RoleAssignmentDefinition parameter in the New-AzResourceGroupRoleAssignment instead of the RoleDefinitionName.
Closes #144