### PR TITLE
feat: Return an object with an empty list property when KV does not exist

### DIFF
--- a/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
+++ b/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
@@ -15,11 +15,11 @@ else
 	$keyVault = Get-AzKeyVault -VaultName $keyVaultName -ResourceGroupName $resourceGroupName
 }
 
-if($keyVault)
-{
-	$armAccessPolicies = @()
-	$keyVaultAccessPolicies = $keyVault.accessPolicies
+$armAccessPolicies = @()
+$keyVaultAccessPolicies = $keyVault.accessPolicies
 
+if($keyVault)
+{	
 	if($keyVaultAccessPolicies)
 	{
 	   Write-Host "Key Vault '$keyVaultName' is found."
@@ -42,16 +42,16 @@ if($keyVault)
 
 		  $armAccessPolicies += $armAccessPolicy
 	   }   
-	}
-
-	$armAccessPoliciesParameter = [pscustomobject]@{
-		list = $armAccessPolicies
-	}
-
-	Write-Host "Current access policies: $armAccessPoliciesParameter"
-	return $armAccessPoliciesParameter
+	}	
 }
 else
 {
 	Write-Warning "KeyVault '$keyVaultName' could not be found."
 }
+
+$armAccessPoliciesParameter = [pscustomobject]@{
+	list = $armAccessPolicies
+}
+
+Write-Host "Current access policies: $armAccessPoliciesParameter"
+return $armAccessPoliciesParameter

--- a/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
+++ b/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
@@ -16,14 +16,15 @@ else
 }
 
 $armAccessPolicies = @()
-$keyVaultAccessPolicies = $keyVault.accessPolicies
 
 if($keyVault)
 {	
-	if($keyVaultAccessPolicies)
-	{
-	   Write-Host "Key Vault '$keyVaultName' is found."
+	Write-Host "Key Vault '$keyVaultName' is found."
 
+	$keyVaultAccessPolicies = $keyVault.accessPolicies
+
+	if($keyVaultAccessPolicies)
+	{	
 	   foreach($keyVaultAccessPolicy in $keyVaultAccessPolicies)
 	   {
 		  $armAccessPolicy = [pscustomobject]@{


### PR DESCRIPTION
When the Get-AzKeyVaultAccesspolicies is run against a non existing KV, make sure that the returned object contains a list property which is empty.
By doing so, the return type is consistent with what we get back when the KV does exist.

#166 