### PR TITLE
fix: add `-AllowPrerelease` to the Pester PS module installation

### DIFF
--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -35,7 +35,7 @@ steps:
                 $content.RequiredModules |
                     where { $_.ModuleName -ne $null -and $_.ModuleVersion -ne "#{Package.Version}#" } |
                     % { Write-Host "Install $($_.ModuleName) module $($_.ModuleVersion)"
-                        Install-Module $_.ModuleName -MaximumVersion $_.ModuleVersion -Force -SkipPublisherCheck } }
+                        Install-Module $_.ModuleName -MaximumVersion $_.ModuleVersion -Force -SkipPublisherCheck -AllowPrerelease } }
         Install-Module -Name Az -Force -SkipPublisherCheck -MaximumVersion 5.6.0
         Write-Host "Done installing, start importing modules"
 


### PR DESCRIPTION
Make sure that we can install preview PS modules when testing the Pester tests.
Otherwise, we can't release preview PS modules.