### PR TITLE
fix: import security PS module as file

### DIFF
--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -39,7 +39,7 @@ steps:
         Install-Module -Name Az -Force -SkipPublisherCheck -MaximumVersion 5.6.0
         Write-Host "Done installing, start importing modules"
 
-        Import-Module ./src/Arcus.Scripting.Security/Arcus.Scripting.Security.psm1
+        Import-Module ./src/Arcus.Scripting.Security/Arcus.Scripting.Security.psd1
         
         Get-ChildItem -Path ./src -Filter *.psm1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
             % { Write-Host "Import $($_.DirectoryName) module"

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -39,7 +39,7 @@ steps:
         Install-Module -Name Az -Force -SkipPublisherCheck -MaximumVersion 5.6.0
         Write-Host "Done installing, start importing modules"
 
-        Import-Module ./src/Arcus.Scripting.Security
+        Import-Module ./src/Arcus.Scripting.Security/Arcus.Scripting.Security.psm1
         
         Get-ChildItem -Path ./src -Filter *.psm1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
             % { Write-Host "Import $($_.DirectoryName) module"


### PR DESCRIPTION
We should import preview modules as script files, so let's use that for all.