### PR TITLE
fix: insert prerelease information during release build

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -33,7 +33,7 @@ variables:
   - group: 'MyGet'
   - template: ./variables/build.yml
   - name: 'Package.Version'
-    value: '0.$(Build.BuildNumber)'
+    value: '0.$(Build.BuildNumber)-preview'
 
 stages:
   - stage: Build

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -59,7 +59,8 @@ stages:
           - powershell: |
               if ('$(Prerelease)' -ne 'none') {
                 Get-ChildItem -Path ./src -Filter *.psd1 -Recurse |
-                  % { $contents = Get-Content $_.FullName
+                  % { Write-Host "Insert prerelease '$(Prerelease)' into PowerShell $($_.Name) datafile"
+                      $contents = Get-Content $_.FullName
                       $contents = $contents -replace "# Prerelease = ''", "Prerelease = '$(Prerelease)'"
                       $contents | Out-File $_.FullName -Force }
               }

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -33,7 +33,7 @@ variables:
   - group: 'MyGet'
   - template: ./variables/build.yml
   - name: 'Package.Version'
-    value: '0.$(Build.BuildNumber)-preview'
+    value: '0.1.0-preview'
 
 stages:
   - stage: Build

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -33,9 +33,7 @@ variables:
   - group: 'MyGet'
   - template: ./variables/build.yml
   - name: 'Package.Version'
-    value: '0.1.0'
-  - name: 'Prerelease'
-    value: '-preview'
+    value: '0.$(Build.BuildNumber)'
 
 stages:
   - stage: Build
@@ -56,15 +54,6 @@ stages:
               keepToken: false
               tokenPrefix: '#{'
               tokenSuffix: '}#'
-          - powershell: |
-              if ('$(Prerelease)' -ne 'none') {
-                Get-ChildItem -Path ./src -Filter *.psd1 -Recurse |
-                  % { Write-Host "Insert prerelease '$(Prerelease)' into PowerShell $($_.Name) datafile"
-                      $contents = Get-Content $_.FullName
-                      $contents = $contents -replace "# Prerelease = ''", "Prerelease = '$(Prerelease)'"
-                      $contents | Out-File $_.FullName -Force }
-              }
-            displayName: 'Set prerelease version'
           - task: CopyFiles@2
             displayName: 'Copy build artifacts'
             inputs:

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -33,7 +33,9 @@ variables:
   - group: 'MyGet'
   - template: ./variables/build.yml
   - name: 'Package.Version'
-    value: '0.1.0-preview'
+    value: '0.1.0'
+  - name: 'Prerelease'
+    value: '-preview'
 
 stages:
   - stage: Build
@@ -54,6 +56,13 @@ stages:
               keepToken: false
               tokenPrefix: '#{'
               tokenSuffix: '}#'
+          ${{ if ne(variables['Prerelease'], 'none') }}:
+            - powershell: |
+                Get-ChildItem -Path ./src -Filter *.psd1 -Recurse |
+                  % { $contents = Get-Content $_.FullName
+                      $contents = $contents -replace "# Prerelease = ''", "Prerelease = '$(Prerelease)'"
+                      $contents | Out-File $_.FullName -Force }
+              displayName: 'Set prerelease version'
           - task: CopyFiles@2
             displayName: 'Copy build artifacts'
             inputs:

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -56,13 +56,14 @@ stages:
               keepToken: false
               tokenPrefix: '#{'
               tokenSuffix: '}#'
-          ${{ if ne(variables['Prerelease'], 'none') }}:
-            - powershell: |
+          - powershell: |
+              if ('$(Prerelease)' -ne 'none') {
                 Get-ChildItem -Path ./src -Filter *.psd1 -Recurse |
                   % { $contents = Get-Content $_.FullName
                       $contents = $contents -replace "# Prerelease = ''", "Prerelease = '$(Prerelease)'"
                       $contents | Out-File $_.FullName -Force }
-              displayName: 'Set prerelease version'
+              }
+            displayName: 'Set prerelease version'
           - task: CopyFiles@2
             displayName: 'Copy build artifacts'
             inputs:

--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -49,6 +49,15 @@ stages:
               keepToken: false
               tokenPrefix: '#{'
               tokenSuffix: '}#'
+          - powershell: |
+              if ('$(Prerelease)' -ne 'none') {
+                Get-ChildItem -Path ./src -Filter *.psd1 -Recurse |
+                  % { Write-Host "Insert prerelease '$(Prerelease)' into PowerShell $($_.Name) datafile"
+                      $contents = Get-Content $_.FullName
+                      $contents = $contents -replace "# Prerelease = ''", "Prerelease = '$(Prerelease)'"
+                      $contents | Out-File $_.FullName -Force }
+              }
+            displayName: 'Set prerelease version'
           - task: CopyFiles@2
             displayName: 'Copy build artifacts'
             inputs:

--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -6,6 +6,10 @@ pr: none
 parameters:
   - name: 'Package.Version'
     type: 'string'
+  - name: 'Prerelease'
+    displayName: 'Prerelease string (ex. -alpha, -alpha1, -BETA, -update20171020) or none'
+    type: 'string'
+    default: 'none'
 
 resources:
   repositories:
@@ -23,6 +27,8 @@ variables:
     value: 'arcus-azure/arcus.scripting'
   - name: 'Package.Version'
     value: ${{ parameters['Package.Version'] }}
+  - name: 'Prerelease'
+    value: ${{ parameters['Prerelease'] }}
 
 stages:
   - stage: Build

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -35,7 +35,7 @@ steps:
                 $content.RequiredModules |
                     where { $_.ModuleName -ne $null -and $_.ModuleVersion -ne "#{Package.Version}#" } |
                     % { Write-Host "Install $($_.ModuleName) module $($_.ModuleVersion)"
-                        Install-Module $_.ModuleName -MaximumVersion $_.ModuleVersion -Force -SkipPublisherCheck -AllowPrerelease } }
+                        Install-Module $_.ModuleName -MaximumVersion $_.ModuleVersion -Force -SkipPublisherCheck } }
         Install-Module -Name Az -Force -SkipPublisherCheck -MaximumVersion 5.6.0
         Write-Host "Done installing, start importing modules"
 
@@ -44,7 +44,7 @@ steps:
         
         Get-ChildItem -Path ./src -Filter *.psm1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
             % { Write-Host "Import $($_.DirectoryName) module"
-                Import-Module -Name $_.DirectoryName -ErrorAction }
+                Import-Module -Name $_.DirectoryName -ErrorAction Stop }
 
         Invoke-Pester -Script "./src/${{ parameters.projectName }}/" -OutputFile "./pester.test.results.xml" -OutputFormat 'NUnitXML' -EnableExit
   - task: PublishTestResults@2

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -33,6 +33,7 @@ steps:
                   % { Write-Host "Install $($_.ModuleName) module $($_.ModuleVersion)"
                       Install-Module $_.ModuleName -MaximumVersion $_.ModuleVersion -Force -SkipPublisherCheck } }
       Install-Module -Name Az -Force -SkipPublisherCheck -MaximumVersion 5.6.0
+      Install-Module -Name AzTable -Force -SkipPublisherCheck -MaximumVersion 2.1.0
       Write-Host "Done installing, start importing modules"
     displayName: 'Install Pester test framework and Az required modules'
   - task: PowerShell@2

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -39,7 +39,8 @@ steps:
         Install-Module -Name Az -Force -SkipPublisherCheck -MaximumVersion 5.6.0
         Write-Host "Done installing, start importing modules"
 
-        if ($env:PACKAGE_VERSION -like "*preview*") {
+        Write-Host 'Package version: $(Package.Version)'
+        if ('$(Package.Version)' -like "*preview*") {
             Install-Module Arcus.Scripting.Security -Force -SkipPublisherCheck
         } else {
             Import-Module ./src/Arcus.Scripting.Security
@@ -50,8 +51,6 @@ steps:
                 Import-Module -Name $_.DirectoryName -ErrorAction Stop }
 
         Invoke-Pester -Script "./src/${{ parameters.projectName }}/" -OutputFile "./pester.test.results.xml" -OutputFormat 'NUnitXML' -EnableExit
-      env:
-        PACKAGE_VERSION: '$(Package.Version)'
   - task: PublishTestResults@2
     displayName: 'Publish test results'
     inputs:

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -29,7 +29,7 @@ steps:
           % { Write-Host "Inspect PowerShell '$($_.Name)' datafile"
               $content = Import-PowerShellDataFile $_.FullName
               $content.RequiredModules |
-                  where { $_.ModuleName -ne $null -and $_.ModuleVersion -ne "#{Package.Version}#" } |
+                  where { $_.ModuleName -ne $null -and $_.ModuleName -notlike 'Arcus.Scripting.*' -and $_.ModuleVersion -ne "#{Package.Version}#" } |
                   % { Write-Host "Install $($_.ModuleName) module $($_.ModuleVersion)"
                       Install-Module $_.ModuleName -MaximumVersion $_.ModuleVersion -Force -SkipPublisherCheck } }
       Install-Module -Name Az -Force -SkipPublisherCheck -MaximumVersion 5.6.0

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -21,6 +21,26 @@ steps:
       keepToken: false
       tokenPrefix: '#{'
       tokenSuffix: '}#'
+  - powershell: |
+      Write-Host "Installing Pester test framework and Az required modules"
+      Install-Module -Name Pester -Force -SkipPublisherCheck -MaximumVersion 5.1.1
+      Get-ChildItem ./src -Filter *.psd1 -Recurse |
+          % { $content = Import-PowerShellDataFile $_.FullName
+              $content.RequiredModules |
+                  where { $_.ModuleName -ne $null -and $_.ModuleVersion -ne "#{Package.Version}#" } |
+                  % { Write-Host "Install $($_.ModuleName) module $($_.ModuleVersion)"
+                      Install-Module $_.ModuleName -MaximumVersion $_.ModuleVersion -Force -SkipPublisherCheck } }
+      Install-Module -Name Az -Force -SkipPublisherCheck -MaximumVersion 5.6.0
+      Write-Host "Done installing, start importing modules"
+    displayName: 'Install Pester test framework and Az required modules'
+  - powershell: |
+      Write-Host 'Package version: $(Package.Version)'
+      Import-Module ./src/Arcus.Scripting.Security
+      
+      Get-ChildItem -Path ./src -Filter *.psm1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
+          % { Write-Host "Import $($_.DirectoryName) module"
+              Import-Module -Name $_.DirectoryName -ErrorAction Stop }
+    displayName: 'Import Arcus PS modules'
   - task: PowerShell@2
     displayName: 'Run Pester tests'
     inputs:
@@ -28,24 +48,6 @@ steps:
       pwsh: true
       failOnStderr: true
       script: |
-        Write-Host "Installing Pester test framework and Az required modules"
-        Install-Module -Name Pester -Force -SkipPublisherCheck -MaximumVersion 5.1.1
-        Get-ChildItem ./src -Filter *.psd1 -Recurse |
-            % { $content = Import-PowerShellDataFile $_.FullName
-                $content.RequiredModules |
-                    where { $_.ModuleName -ne $null -and $_.ModuleVersion -ne "#{Package.Version}#" } |
-                    % { Write-Host "Install $($_.ModuleName) module $($_.ModuleVersion)"
-                        Install-Module $_.ModuleName -MaximumVersion $_.ModuleVersion -Force -SkipPublisherCheck } }
-        Install-Module -Name Az -Force -SkipPublisherCheck -MaximumVersion 5.6.0
-        Write-Host "Done installing, start importing modules"
-
-        Write-Host 'Package version: $(Package.Version)'
-        Import-Module ./src/Arcus.Scripting.Security
-        
-        Get-ChildItem -Path ./src -Filter *.psm1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
-            % { Write-Host "Import $($_.DirectoryName) module"
-                Import-Module -Name $_.DirectoryName -ErrorAction Stop }
-
         Invoke-Pester -Script "./src/${{ parameters.projectName }}/" -OutputFile "./pester.test.results.xml" -OutputFormat 'NUnitXML' -EnableExit
   - task: PublishTestResults@2
     displayName: 'Publish test results'

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -48,7 +48,7 @@ steps:
         
         Get-ChildItem -Path ./src -Filter *.psd1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
             % { Write-Host "Import $($_.DirectoryName) module"
-                Import-Module -Name $_.FullName -ErrorAction Stop }
+                Import-Module -Name $_.FullName -ErrorAction Stop -Global }
 
         Invoke-Pester -Script "./src/${{ parameters.projectName }}/" -OutputFile "./pester.test.results.xml" -OutputFormat 'NUnitXML' -EnableExit
   - task: PublishTestResults@2

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -46,9 +46,12 @@ steps:
             Import-Module ./src/Arcus.Scripting.Security
         }
         
-        Get-ChildItem -Path ./src -Filter *.psd1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
+        Get-ChildItem -Path ./src -Filter *.psm1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
             % { Write-Host "Import $($_.DirectoryName) module"
-                Import-Module -Name $_.FullName -ErrorAction Stop -Global }
+                if ('$(Package.Version)' -like "*preview*") {
+                    Install-Module $_.DirectoryName -Force -SkipPublisherCheck
+                }
+                Import-Module -Name $_.DirectoryName -ErrorAction }
 
         Invoke-Pester -Script "./src/${{ parameters.projectName }}/" -OutputFile "./pester.test.results.xml" -OutputFormat 'NUnitXML' -EnableExit
   - task: PublishTestResults@2

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -39,7 +39,7 @@ steps:
         Install-Module -Name Az -Force -SkipPublisherCheck -MaximumVersion 5.6.0
         Write-Host "Done installing, start importing modules"
 
-        Import-Module ./src/Arcus.Scripting.Security
+        Import-Module ./src/Arcus.Scripting.Security/Arcus.Scripting.Security.psd1
         
         Get-ChildItem -Path ./src -Filter *.psm1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
             % { Write-Host "Import $($_.DirectoryName) module"

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -46,9 +46,9 @@ steps:
             Import-Module ./src/Arcus.Scripting.Security
         }
         
-        Get-ChildItem -Path ./src -Filter *.psm1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
+        Get-ChildItem -Path ./src -Filter *.psd1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
             % { Write-Host "Import $($_.DirectoryName) module"
-                Import-Module -Name $_.DirectoryName -ErrorAction Stop }
+                Import-Module -Name $_.FullName -ErrorAction Stop }
 
         Invoke-Pester -Script "./src/${{ parameters.projectName }}/" -OutputFile "./pester.test.results.xml" -OutputFormat 'NUnitXML' -EnableExit
   - task: PublishTestResults@2

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -39,7 +39,11 @@ steps:
         Install-Module -Name Az -Force -SkipPublisherCheck -MaximumVersion 5.6.0
         Write-Host "Done installing, start importing modules"
 
-        Import-Module ./src/Arcus.Scripting.Security/Arcus.Scripting.Security.psd1
+        if ("$(Package.Version)" -like "*preview*") {
+            Install-Module Arcus.Scripting.Security -Force -SkipPublisherCheck
+        } else {
+            Import-Module ./src/Arcus.Scripting.Security
+        }
         
         Get-ChildItem -Path ./src -Filter *.psm1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
             % { Write-Host "Import $($_.DirectoryName) module"

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -9,6 +9,7 @@ steps:
       fi
     env:
       PROJECT_NAME: ${{ parameters.projectName }}
+    displayName: 'Guard against invalid parameters'
   - task: qetza.replacetokens.replacetokens-task.replacetokens@3
     displayName: 'Replace integration test tokens'
     inputs:
@@ -24,8 +25,9 @@ steps:
   - powershell: |
       Write-Host "Installing Pester test framework and Az required modules"
       Install-Module -Name Pester -Force -SkipPublisherCheck -MaximumVersion 5.1.1
-      Get-ChildItem ./src -Filter *.psd1 -Recurse |
-          % { $content = Import-PowerShellDataFile $_.FullName
+      Get-ChildItem ./src -Filter *.psd1 -Recurse -Exclude "*.All.psd1" |
+          % { Write-Host "Inspect PowerShell '$($_.Name)' datafile"
+              $content = Import-PowerShellDataFile $_.FullName
               $content.RequiredModules |
                   where { $_.ModuleName -ne $null -and $_.ModuleVersion -ne "#{Package.Version}#" } |
                   % { Write-Host "Install $($_.ModuleName) module $($_.ModuleVersion)"

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -40,17 +40,10 @@ steps:
         Write-Host "Done installing, start importing modules"
 
         Write-Host 'Package version: $(Package.Version)'
-        if ('$(Package.Version)' -like "*preview*") {
-            Install-Module Arcus.Scripting.Security -Force -SkipPublisherCheck
-        } else {
-            Import-Module ./src/Arcus.Scripting.Security
-        }
+        Import-Module ./src/Arcus.Scripting.Security
         
         Get-ChildItem -Path ./src -Filter *.psm1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
             % { Write-Host "Import $($_.DirectoryName) module"
-                if ('$(Package.Version)' -like "*preview*") {
-                    Install-Module $_.DirectoryName -Force -SkipPublisherCheck
-                }
                 Import-Module -Name $_.DirectoryName -ErrorAction }
 
         Invoke-Pester -Script "./src/${{ parameters.projectName }}/" -OutputFile "./pester.test.results.xml" -OutputFormat 'NUnitXML' -EnableExit

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -35,14 +35,6 @@ steps:
       Install-Module -Name Az -Force -SkipPublisherCheck -MaximumVersion 5.6.0
       Write-Host "Done installing, start importing modules"
     displayName: 'Install Pester test framework and Az required modules'
-  - powershell: |
-      Write-Host 'Package version: $(Package.Version)'
-      Import-Module ./src/Arcus.Scripting.Security
-      
-      Get-ChildItem -Path ./src -Filter *.psm1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
-          % { Write-Host "Import $($_.DirectoryName) module"
-              Import-Module -Name $_.DirectoryName -ErrorAction Stop }
-    displayName: 'Import Arcus PS modules'
   - task: PowerShell@2
     displayName: 'Run Pester tests'
     inputs:
@@ -50,6 +42,11 @@ steps:
       pwsh: true
       failOnStderr: true
       script: |
+        Import-Module ./src/Arcus.Scripting.Security
+      
+        Get-ChildItem -Path ./src -Filter *.psm1 -Recurse -Exclude "*Arcus.Scripting.Security*", "*.All.psm1" |
+          % { Write-Host "Import $($_.DirectoryName) module"
+              Import-Module -Name $_.DirectoryName -ErrorAction Stop }
         Invoke-Pester -Script "./src/${{ parameters.projectName }}/" -OutputFile "./pester.test.results.xml" -OutputFormat 'NUnitXML' -EnableExit
   - task: PublishTestResults@2
     displayName: 'Publish test results'

--- a/build/templates/run-pester-tests.yml
+++ b/build/templates/run-pester-tests.yml
@@ -39,7 +39,7 @@ steps:
         Install-Module -Name Az -Force -SkipPublisherCheck -MaximumVersion 5.6.0
         Write-Host "Done installing, start importing modules"
 
-        if ("$(Package.Version)" -like "*preview*") {
+        if ($env:PACKAGE_VERSION -like "*preview*") {
             Install-Module Arcus.Scripting.Security -Force -SkipPublisherCheck
         } else {
             Import-Module ./src/Arcus.Scripting.Security
@@ -50,6 +50,8 @@ steps:
                 Import-Module -Name $_.DirectoryName -ErrorAction Stop }
 
         Invoke-Pester -Script "./src/${{ parameters.projectName }}/" -OutputFile "./pester.test.results.xml" -OutputFormat 'NUnitXML' -EnableExit
+      env:
+        PACKAGE_VERSION: '$(Package.Version)'
   - task: PublishTestResults@2
     displayName: 'Publish test results'
     inputs:


### PR DESCRIPTION
We should consider using the security PS module of the gallery when building preview packages.