### PR TITLE
fix: prerelease nuget generation

### DIFF
--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -26,7 +26,7 @@ variables:
   - name: 'Repository'
     value: 'arcus-azure/arcus.scripting'
   - name: 'Package.Version'
-    value: ${{ parameters['Package.Version'] }}
+    value: "${{ parameters['Package.Version'] }}${{ parameters['Prerelease'] }}"
   - name: 'Prerelease'
     value: ${{ parameters['Prerelease'] }}
 

--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -26,7 +26,7 @@ variables:
   - name: 'Repository'
     value: 'arcus-azure/arcus.scripting'
   - name: 'Package.Version'
-    value: "${{ parameters['Package.Version'] }}"
+    value: "${{ parameters['Package.Version'] }}${{ parameters['Package.Version'] }}"
   - name: 'Prerelease'
     value: ${{ parameters['Prerelease'] }}
 

--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -26,7 +26,7 @@ variables:
   - name: 'Repository'
     value: 'arcus-azure/arcus.scripting'
   - name: 'Package.Version'
-    value: "${{ parameters['Package.Version'] }}${{ parameters['Package.Version'] }}"
+    value: "${{ parameters['Package.Version'] }}${{ parameters['Prerelease'] }}"
   - name: 'Prerelease'
     value: ${{ parameters['Prerelease'] }}
 

--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -129,14 +129,14 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-         # - template: github/create-release.yml@templates
-         #   parameters:
-         #     repositoryName: '$(Repository)'
-         #     releaseNotes: |
-         #       Install new version via [PowerShell Gallery](https://www.powershellgallery.com/packages?q=$(Project).ARM)
-         #       ```shell
-         #       PS > Install-Module -Name $(Project).ARM --Version $(Build.BuildNumber)
-         #       ```
+          - template: github/create-release.yml@templates
+            parameters:
+              repositoryName: '$(Repository)'
+              releaseNotes: |
+                Install new version via [PowerShell Gallery](https://www.powershellgallery.com/packages?q=$(Project).ARM)
+                ```shell
+                PS > Install-Module -Name $(Project).ARM --Version $(Build.BuildNumber)
+                ```
           - powershell: |
               Import-Module PowerShellGet -Force
               Get-ChildItem -Path ./src -Filter *.psd1 -Recurse |
@@ -149,11 +149,11 @@ stages:
               command: 'pack'
               packagesToPack: '**/*.nuspec'
               packDestination: '$(Build.ArtifactStagingDirectory)'
-         # - task: NuGetToolInstaller@1
-         #   displayName: 'Install NuGet'
-         # - powershell: |
-         #     Get-ChildItem -Path $env:ARTIFACT_DIR -Filter *.nupkg -Recurse |
-         #       % { & "nuget" push $_.FullName -Source $(Source) -ApiKey $(NuGet.ApiKey) -SkipDuplicate }
-         #   displayName: 'Push to PowerShell Gallery'
-         #   env:
-         #     ARTIFACT_DIR: '$(Build.ArtifactStagingDirectory)'
+          - task: NuGetToolInstaller@1
+            displayName: 'Install NuGet'
+          - powershell: |
+              Get-ChildItem -Path $env:ARTIFACT_DIR -Filter *.nupkg -Recurse |
+                % { & "nuget" push $_.FullName -Source $(Source) -ApiKey $(NuGet.ApiKey) -SkipDuplicate }
+            displayName: 'Push to PowerShell Gallery'
+            env:
+              ARTIFACT_DIR: '$(Build.ArtifactStagingDirectory)'

--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -122,8 +122,7 @@ stages:
           vmImage: '$(Vm.Image)'
         variables:
           ${{ if ne(variables['Prerelease'], 'none') }}:
-            - name: 'Package.Version'
-              value: "${{ parameters['Package.Version'] }}${{ parameters['Prerelease'] }}"
+            Package.Version: "${{ parameters['Package.Version'] }}${{ parameters['Prerelease'] }}"
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'

--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -126,31 +126,31 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: github/create-release.yml@templates
-            parameters:
-              repositoryName: '$(Repository)'
-              releaseNotes: |
-                Install new version via [PowerShell Gallery](https://www.powershellgallery.com/packages?q=$(Project).ARM)
-                ```shell
-                PS > Install-Module -Name $(Project).ARM --Version $(Build.BuildNumber)
-                ```
+         # - template: github/create-release.yml@templates
+         #   parameters:
+         #     repositoryName: '$(Repository)'
+         #     releaseNotes: |
+         #       Install new version via [PowerShell Gallery](https://www.powershellgallery.com/packages?q=$(Project).ARM)
+         #       ```shell
+         #       PS > Install-Module -Name $(Project).ARM --Version $(Build.BuildNumber)
+         #       ```
           - powershell: |
               Import-Module PowerShellGet -Force
               Get-ChildItem -Path ./src -Filter *.psd1 -Recurse |
                 % { & $env:SCRIPT_PATH -ManifestPath $_.FullName -DestinationFolder $_.DirectoryName }
             displayName: 'Generate .nuspec file for each PowerShell module'
             env:
-              SCRIPT_PATH: '$(Build.SourcesDirectory)\build\tools\psd1-to-nuspec.ps1'
+             SCRIPT_PATH: '$(Build.SourcesDirectory)\build\tools\psd1-to-nuspec.ps1'
           - task: NuGetCommand@2
             inputs:
               command: 'pack'
               packagesToPack: '**/*.nuspec'
               packDestination: '$(Build.ArtifactStagingDirectory)'
-          - task: NuGetToolInstaller@1
-            displayName: 'Install NuGet'
-          - powershell: |
-              Get-ChildItem -Path $env:ARTIFACT_DIR -Filter *.nupkg -Recurse |
-                % { & "nuget" push $_.FullName -Source $(Source) -ApiKey $(NuGet.ApiKey) -SkipDuplicate }
-            displayName: 'Push to PowerShell Gallery'
-            env:
-              ARTIFACT_DIR: '$(Build.ArtifactStagingDirectory)'
+         # - task: NuGetToolInstaller@1
+         #   displayName: 'Install NuGet'
+         # - powershell: |
+         #     Get-ChildItem -Path $env:ARTIFACT_DIR -Filter *.nupkg -Recurse |
+         #       % { & "nuget" push $_.FullName -Source $(Source) -ApiKey $(NuGet.ApiKey) -SkipDuplicate }
+         #   displayName: 'Push to PowerShell Gallery'
+         #   env:
+         #     ARTIFACT_DIR: '$(Build.ArtifactStagingDirectory)'

--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -26,7 +26,7 @@ variables:
   - name: 'Repository'
     value: 'arcus-azure/arcus.scripting'
   - name: 'Package.Version'
-    value: "${{ parameters['Package.Version'] }}${{ parameters['Prerelease'] }}"
+    value: "${{ parameters['Package.Version'] }}"
   - name: 'Prerelease'
     value: ${{ parameters['Prerelease'] }}
 
@@ -120,6 +120,10 @@ stages:
         displayName: 'Push to PowerShell Gallery'
         pool:
           vmImage: '$(Vm.Image)'
+        variables:
+          ${{ if ne(variables['Prerelease'], 'none') }}:
+            - name: 'Package.Version'
+              value: "${{ parameters['Package.Version'] }}${{ parameters['Prerelease'] }}"
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'

--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -26,7 +26,7 @@ variables:
   - name: 'Repository'
     value: 'arcus-azure/arcus.scripting'
   - name: 'Package.Version'
-    value: "${{ parameters['Package.Version'] }}${{ parameters['Prerelease'] }}"
+    value: "${{ parameters['Package.Version'] }}"
   - name: 'Prerelease'
     value: ${{ parameters['Prerelease'] }}
 

--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -26,7 +26,7 @@ variables:
   - name: 'Repository'
     value: 'arcus-azure/arcus.scripting'
   - name: 'Package.Version'
-    value: "${{ parameters['Package.Version'] }}"
+    value: ${{ parameters['Package.Version'] }}
   - name: 'Prerelease'
     value: ${{ parameters['Prerelease'] }}
 

--- a/build/tools/psd1-to-nuspec.ps1
+++ b/build/tools/psd1-to-nuspec.ps1
@@ -382,16 +382,17 @@ function New-NuSpecFile
     }
   }
  
-  # Toggled out - not needed
-  $dscResourceNames = Get-ExportedDscResources -PSModuleInfo $PSModuleInfo
-  if($dscResourceNames)
-  {
-    $Tags += 'PSIncludes_DscResource'
+  # Toggled out - not needed and causing exceptions when building prereleases
+  # -------------------------------------------------------------------------
+  #$dscResourceNames = Get-ExportedDscResources -PSModuleInfo $PSModuleInfo
+  #if($dscResourceNames)
+  #{
+  #  $Tags += 'PSIncludes_DscResource'
 
-    $Tags += $dscResourceNames | Microsoft.PowerShell.Core\ForEach-Object {
-      "PSDscResource_$_"
-    }
-  }
+  #  $Tags += $dscResourceNames | Microsoft.PowerShell.Core\ForEach-Object {
+  #    "PSDscResource_$_"
+  #  }
+  #}
 
   $RoleCapabilityNames = Get-AvailableRoleCapabilityName -PSModuleInfo $PSModuleInfo
   if($RoleCapabilityNames)

--- a/build/tools/psd1-to-nuspec.ps1
+++ b/build/tools/psd1-to-nuspec.ps1
@@ -383,15 +383,15 @@ function New-NuSpecFile
   }
  
   # Toggled out - not needed
-  #$dscResourceNames = Get-ExportedDscResources -PSModuleInfo $PSModuleInfo
-  #if($dscResourceNames)
-  #{
-  #  $Tags += 'PSIncludes_DscResource'
+  $dscResourceNames = Get-ExportedDscResources -PSModuleInfo $PSModuleInfo
+  if($dscResourceNames)
+  {
+    $Tags += 'PSIncludes_DscResource'
 
-  #  $Tags += $dscResourceNames | Microsoft.PowerShell.Core\ForEach-Object {
-  #    "PSDscResource_$_"
-  #  }
-  #}
+    $Tags += $dscResourceNames | Microsoft.PowerShell.Core\ForEach-Object {
+      "PSDscResource_$_"
+    }
+  }
 
   $RoleCapabilityNames = Get-AvailableRoleCapabilityName -PSModuleInfo $PSModuleInfo
   if($RoleCapabilityNames)

--- a/build/tools/psd1-to-nuspec.ps1
+++ b/build/tools/psd1-to-nuspec.ps1
@@ -40,7 +40,6 @@ function Get-EscapedString
 
   return [System.Security.SecurityElement]::Escape($ElementValue)
 }
- Toggled out - not needed
 function Get-ExportedDscResources
 {
   [CmdletBinding(PositionalBinding = $false)]

--- a/build/tools/psd1-to-nuspec.ps1
+++ b/build/tools/psd1-to-nuspec.ps1
@@ -40,6 +40,7 @@ function Get-EscapedString
 
   return [System.Security.SecurityElement]::Escape($ElementValue)
 }
+ Toggled out - not needed
 function Get-ExportedDscResources
 {
   [CmdletBinding(PositionalBinding = $false)]
@@ -381,16 +382,17 @@ function New-NuSpecFile
       "PSCommand_$_"
     }
   }
+ 
+  # Toggled out - not needed
+  #$dscResourceNames = Get-ExportedDscResources -PSModuleInfo $PSModuleInfo
+  #if($dscResourceNames)
+  #{
+  #  $Tags += 'PSIncludes_DscResource'
 
-  $dscResourceNames = Get-ExportedDscResources -PSModuleInfo $PSModuleInfo
-  if($dscResourceNames)
-  {
-    $Tags += 'PSIncludes_DscResource'
-
-    $Tags += $dscResourceNames | Microsoft.PowerShell.Core\ForEach-Object {
-      "PSDscResource_$_"
-    }
-  }
+  #  $Tags += $dscResourceNames | Microsoft.PowerShell.Core\ForEach-Object {
+  #    "PSDscResource_$_"
+  #  }
+  #}
 
   $RoleCapabilityNames = Get-AvailableRoleCapabilityName -PSModuleInfo $PSModuleInfo
   if($RoleCapabilityNames)


### PR DESCRIPTION
Trouble when building prereleases NuGet packages. Seems like there's a problem with the tool-script we're using.
Including exported DSC resources causing the problem, but since we're not using that, I commented out and documented.