### PR TITLE
test: set arm outputs to az devops variable group (🚧)

### DIFF
--- a/src/Arcus.Scripting.DevOps/Scripts/Set-AzDevOpsArmOutputs.ps1
+++ b/src/Arcus.Scripting.DevOps/Scripts/Set-AzDevOpsArmOutputs.ps1
@@ -37,9 +37,9 @@ function Add-VariableGroupVariable()
 
         #Get variable group
         Write-Host Get variable group
-        $getVariableGroupUrl= $projectUri + $project + "/_apis/distributedtask/variablegroups?api-version=" + $apiVersion + "&groupName=" + $VariableGroupName
+        $getVariableGroupUrl= $projectUri + $project + "/_apis/distributedtask/variablegroups?api-version=" + $apiVersion + "&groupName=" + [uri]::EscapeDataString($VariableGroupName)
         $variableGroup = (Invoke-RestMethod -Uri $getVariableGroupUrl -Headers $headers -Verbose) 
-        Write-Host $variableGroup
+        Write-Host "GET variable group: $variableGroup"
 
         if($variableGroup.value)
         {

--- a/src/Arcus.Scripting.DevOps/Scripts/Set-AzDevOpsArmOutputs.ps1
+++ b/src/Arcus.Scripting.DevOps/Scripts/Set-AzDevOpsArmOutputs.ps1
@@ -21,7 +21,7 @@ function Add-VariableGroupVariable()
         
         [String]$project = "$env:SYSTEM_TEAMPROJECT"
         [String]$projectUri = "$env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI"
-        [String]$apiVersion = "4.1-preview.1"
+        [String]$apiVersion = "6.0-preview.2"
         
         Write-Host Project: $project
         Write-Host ProjectUri: $projectUri
@@ -37,7 +37,7 @@ function Add-VariableGroupVariable()
 
         #Get variable group
         Write-Host Get variable group
-        $getVariableGroupUrl= $projectUri + $project + "/_apis/distributedtask/variablegroups?api-version=" + $apiVersion + "&groupName=" + [uri]::EscapeDataString($VariableGroupName)
+        $getVariableGroupUrl= $projectUri + $project + "/_apis/distributedtask/variablegroups?api-version=" + $apiVersion + "&groupName=" + $VariableGroupName
         $variableGroup = (Invoke-RestMethod -Uri $getVariableGroupUrl -Headers $headers -Verbose) 
         Write-Host "GET variable group: $variableGroup"
 

--- a/src/Arcus.Scripting.DevOps/Scripts/Set-AzDevOpsArmOutputs.ps1
+++ b/src/Arcus.Scripting.DevOps/Scripts/Set-AzDevOpsArmOutputs.ps1
@@ -46,7 +46,7 @@ function Add-VariableGroupVariable()
             #Set properties for update of existing variable group
             Write-Host Set properties for update of existing variable group
             $variableGroup = $variableGroup.value[0]
-			$variableGroup | Add-Member -Name "description" -MemberType NoteProperty -Value "Variable group that got auto-updated by release '$env:Release_ReleaseName'." -Force
+            $variableGroup | Add-Member -Name "description" -MemberType NoteProperty -Value "Variable group that got auto-updated by release '$env:Release_ReleaseName'." -Force
             $method = "Put"
             $upsertVariableGroupUrl = $projectUri + $project + "/_apis/distributedtask/variablegroups/" + $variableGroup.id + "?api-version=" + $apiVersion    
         }

--- a/src/Arcus.Scripting.DevOps/Scripts/Set-AzDevOpsArmOutputs.ps1
+++ b/src/Arcus.Scripting.DevOps/Scripts/Set-AzDevOpsArmOutputs.ps1
@@ -35,12 +35,12 @@ function Add-VariableGroupVariable()
         }
         $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
 
-
         #Get variable group
         Write-Host Get variable group
         $getVariableGroupUrl= $projectUri + $project + "/_apis/distributedtask/variablegroups?api-version=" + $apiVersion + "&groupName=" + $VariableGroupName
         $variableGroup = (Invoke-RestMethod -Uri $getVariableGroupUrl -Headers $headers -Verbose) 
-        
+        Write-Host $variableGroup
+
         if($variableGroup.value)
         {
             #Set properties for update of existing variable group

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -48,7 +48,7 @@ InModuleScope Arcus.Scripting.DevOps {
                 $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
                 $variableGroup = $null
 
-                try {
+                #try {
                     # Act
                     Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName $existingVariableGroup
 
@@ -58,14 +58,14 @@ InModuleScope Arcus.Scripting.DevOps {
                     $variableGroup = $variableGroup.value[0]
                     $variableGroup.variables.$variableName | Should -Not -Be $null
                     $variableGroup.variables.$variableName.value | Should -Be "@{value=$variableValue}"
-                } finally {
+                #} finally {
                     $variableGroup | Add-Member -Name "description" -MemberType NoteProperty -Value "Variable group reverted" -Force
                     $variableGroup.variables.PSObject.Members.Remove($variableName)
 
                     $upsertVariableGroupUrl = $projectUri + $project + "/_apis/distributedtask/variablegroups/" + $variableGroup.id + "?api-version=" + $apiVersion 
                     $body = $variableGroup | ConvertTo-Json -Depth 10 -Compress
                     Invoke-RestMethod $upsertVariableGroupUrl -Method "Put" -Body $body -Headers $headers -ContentType 'application/json; charset=utf-8' -Verbose
-                }
+                #}
             }
         }
     }

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -33,5 +33,39 @@ InModuleScope Arcus.Scripting.DevOps {
                 }
             }
         }
+        Context "Set ARM outputs as DevOps variable" {
+            It "Adds ARM outputs as a new default DevOps variable to an existing variable group" {
+                # Arrange
+                $existingVariableGroup = $config.Arcus.DevOps.VariableGroup.Name
+                $variableName = "MyVariable"
+                $variableValue = [System.Guid]::NewGuid()
+                $env:ArmOutputs = "{ ""$existingVariableGroup"": [ { ""Name"": ""$variableName"", ""Value"": { ""value"": ""$variableValue"" } } ] }"
+
+                $project = "$env:SYSTEM_TEAMPROJECT"
+                $projectUri = "$env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI"
+                $apiVersion = "4.1-preview.1"
+                $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
+                $variableGroup = $null
+
+                try {
+                    # Act
+                    Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName $existingVariableGroup
+
+                    # Assert
+                    $getVariableGroupUrl= $projectUri + $project + "/_apis/distributedtask/variablegroups?api-version=" + $apiVersion + "&groupName=" + $existingVariableGroup
+                    $variableGroup = Invoke-RestMethod -Uri $getVariableGroupUrl -Headers $headers -Verbose
+                    $variableGroup = $variableGroup.value[0]
+                    $variableGroup.variables.$variableName | Should -Not -Be $null
+                    $variableGroup.variables.$variableName.value | Should -Be $variableValue
+                finally {
+                    $variableGroup | Add-Member -Name "description" -MemberType NoteProperty -Value "Variable group reverted" -Force
+                    $variableGroup = $variableGroup.variables | Select-Object -Property * -ExcludeProperty $variableName
+                    
+                    $upsertVariableGroupUrl = $projectUri + $project + "/_apis/distributedtask/variablegroups/" + $variableGroup.id + "?api-version=" + $apiVersion 
+                    $body = $variableGroup | ConvertTo-Json -Depth 10 -Compress
+                    Invoke-RestMethod $upsertVariableGroupUrl -Method "Put" -Body $body -Headers $headers -ContentType 'application/json; charset=utf-8' -Verbose
+                }
+            }
+        }
     }
 }

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -48,7 +48,7 @@ InModuleScope Arcus.Scripting.DevOps {
                 $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
                 $variableGroup = $null
 
-                #try {
+                try {
                     # Act
                     Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName $existingVariableGroup
 
@@ -58,14 +58,14 @@ InModuleScope Arcus.Scripting.DevOps {
                     $variableGroup = $variableGroup.value[0]
                     $variableGroup.variables.$variableName | Should -Not -Be $null
                     $variableGroup.variables.$variableName.value | Should -Be "@{value=$variableValue}"
-                #} finally {
+                } finally {
                     $variableGroup | Add-Member -Name "description" -MemberType NoteProperty -Value "Variable group reverted" -Force
                     $variableGroup.variables.PSObject.Members.Remove($variableName)
 
                     $upsertVariableGroupUrl = $projectUri + $project + "/_apis/distributedtask/variablegroups/" + $variableGroup.id + "?api-version=" + $apiVersion 
                     $body = $variableGroup | ConvertTo-Json -Depth 10 -Compress
                     Invoke-RestMethod $upsertVariableGroupUrl -Method "Put" -Body $body -Headers $headers -ContentType 'application/json; charset=utf-8' -Verbose
-                #}
+                }
             }
         }
     }

--- a/src/Arcus.Scripting.Tests.Integration/appsettings.json
+++ b/src/Arcus.Scripting.Tests.Integration/appsettings.json
@@ -6,6 +6,11 @@
       "ClientId": "#{Arcus.ServicePrincipal.ClientId}#",
       "ClientSecret": "#{Arcus.ServicePrincipal.ClientSecret}#"
     },
+    "DevOps": {
+      "VariableGroup": {
+        "Name": "#{Arcus.DevOps.VariableGroup.Name}#" 
+      } 
+    },
     "KeyVault": {
       "VaultName": "#{Arcus.KeyVault.VaultName}#"
     },


### PR DESCRIPTION
Adds integration tests for the PS script that sets the ARM outputs as variables in Azure DevOps variable groups.

Relates to #174 