### PR TITLE
docs: add versioned module installations

### DIFF
--- a/docs/preview/01-index.md
+++ b/docs/preview/01-index.md
@@ -5,8 +5,6 @@ slug: /
 sidebar_label: Welcome
 ---
 
-![PowerShell Gallery Version](https://img.shields.io/powershellgallery/v/Arcus.Scripting.All)
-
 # Installation
 
 The Arcus.Scripting modules can be found on the PowerShell gallery.

--- a/docs/versioned_docs/version-v0.1.3/01-index.md
+++ b/docs/versioned_docs/version-v0.1.3/01-index.md
@@ -11,7 +11,7 @@ The Arcus.Scripting modules can be found on the PowerShell gallery.
 Install the latest version of a module by executing the following command:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -MaximumVersion 0.1.3
+PS> Install-Module -Name Arcus.Scripting.ARM -RequiredVersion 0.1.3
 ```
 
 For more granular packages we recommend reading the documentation.

--- a/docs/versioned_docs/version-v0.1.3/01-index.md
+++ b/docs/versioned_docs/version-v0.1.3/01-index.md
@@ -5,15 +5,13 @@ slug: /
 sidebar_label: Welcome
 ---
 
-[![PowerShell Gallery Version](https://img.shields.io/badge/powershell%20gallery-v0.1.3-orange)](https://www.powershellgallery.com/packages/Arcus.Scripting.ARM/0.1.3)
-
 # Installation
 
 The Arcus.Scripting modules can be found on the PowerShell gallery.
 Install the latest version of a module by executing the following command:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -Version 0.1.3
+PS> Install-Module -Name Arcus.Scripting.ARM -MinimumVersion 0.1.3
 ```
 
 For more granular packages we recommend reading the documentation.

--- a/docs/versioned_docs/version-v0.1.3/01-index.md
+++ b/docs/versioned_docs/version-v0.1.3/01-index.md
@@ -11,7 +11,7 @@ The Arcus.Scripting modules can be found on the PowerShell gallery.
 Install the latest version of a module by executing the following command:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -MinimumVersion 0.1.3
+PS> Install-Module -Name Arcus.Scripting.ARM -MaximumVersion 0.1.3
 ```
 
 For more granular packages we recommend reading the documentation.

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -MaximumVersion 0.1.3
+PS> Install-Module -Name Arcus.Scripting.ARM -RequiredVersion 0.1.3
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM
+PS> Install-Module -Name Arcus.Scripting.ARM -MinimumVersion 0.1.3
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -MinimumVersion 0.1.3
+PS> Install-Module -Name Arcus.Scripting.ARM -MaximumVersion 0.1.3
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-api-management.md
@@ -17,7 +17,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement -MinimumVersion 0.1.3
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -MaximumVersion 0.1.3
 ```
 
 ## Creating a new API operation in the Azure API Management instance

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-api-management.md
@@ -17,7 +17,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -MinimumVersion 0.1.3
 ```
 
 ## Creating a new API operation in the Azure API Management instance

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-api-management.md
@@ -17,7 +17,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement -MaximumVersion 0.1.3
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -RequiredVersion 0.1.3
 ```
 
 ## Creating a new API operation in the Azure API Management instance

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory -MinimumVersion 0.1.3
+PS> Install-Module -Name Arcus.Scripting.DataFactory -MaximumVersion 0.1.3
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory -MaximumVersion 0.1.3
+PS> Install-Module -Name Arcus.Scripting.DataFactory -RequiredVersion 0.1.3
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory
+PS> Install-Module -Name Arcus.Scripting.DataFactory -MinimumVersion 0.1.3
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-devops.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps -MaximumVersion 0.1.3
+PS> Install-Module -Name Arcus.Scripting.DevOps -RequiredVersion 0.1.3
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-devops.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps -MinimumVersion 0.1.3
+PS> Install-Module -Name Arcus.Scripting.DevOps -MaximumVersion 0.1.3
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-devops.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps
+PS> Install-Module -Name Arcus.Scripting.DevOps -MinimumVersion 0.1.3
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-key-vault.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault -MaximumVersion 0.1.3
+PS> Install-Module -Name Arcus.Scripting.KeyVault -RequiredVersion 0.1.3
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-key-vault.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault -MinimumVersion 0.1.3
+PS> Install-Module -Name Arcus.Scripting.KeyVault -MaximumVersion 0.1.3
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-key-vault.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault
+PS> Install-Module -Name Arcus.Scripting.KeyVault -MinimumVersion 0.1.3
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-storage.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-storage.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -MinimumVersion 0.1.3
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-storage.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-storage.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table -MaximumVersion 0.1.3
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -RequiredVersion 0.1.3
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-storage.md
+++ b/docs/versioned_docs/version-v0.1.3/02-Features/powershell/azure-storage.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table -MinimumVersion 0.1.3
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -MaximumVersion 0.1.3
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.2/01-index.md
+++ b/docs/versioned_docs/version-v0.2/01-index.md
@@ -5,8 +5,6 @@ slug: /
 sidebar_label: Welcome
 ---
 
-[![PowerShell Gallery Version](https://img.shields.io/badge/powershell%20gallery-v0.2.0-orange)](https://www.powershellgallery.com/packages/Arcus.Scripting.ARM/0.2.0)
-
 # Installation
 
 The Arcus.Scripting modules can be found on the PowerShell gallery.

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM
+PS> Install-Module -Name Arcus.Scripting.ARM --MinimumVersion 0.2.0
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM --MaximumVersion 0.2.0
+PS> Install-Module -Name Arcus.Scripting.ARM --RequiredVersion 0.2.0
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM --MinimumVersion 0.2.0
+PS> Install-Module -Name Arcus.Scripting.ARM --MaximumVersion 0.2.0
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-api-management.md
@@ -18,7 +18,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement --MaximumVersion 0.2.0
+PS> Install-Module -Name Arcus.Scripting.ApiManagement --RequiredVersion 0.2.0
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-api-management.md
@@ -18,7 +18,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement --MinimumVersion 0.2.0
+PS> Install-Module -Name Arcus.Scripting.ApiManagement --MaximumVersion 0.2.0
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-api-management.md
@@ -18,7 +18,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement
+PS> Install-Module -Name Arcus.Scripting.ApiManagement --MinimumVersion 0.2.0
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory --MinimumVersion 0.2.0
+PS> Install-Module -Name Arcus.Scripting.DataFactory --MaximumVersion 0.2.0
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory
+PS> Install-Module -Name Arcus.Scripting.DataFactory --MinimumVersion 0.2.0
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory --MaximumVersion 0.2.0
+PS> Install-Module -Name Arcus.Scripting.DataFactory --RequiredVersion 0.2.0
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-devops.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps --MaximumVersion 0.2.0
+PS> Install-Module -Name Arcus.Scripting.DevOps --RequiredVersion 0.2.0
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-devops.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps --MinimumVersion 0.2.0
+PS> Install-Module -Name Arcus.Scripting.DevOps --MaximumVersion 0.2.0
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-devops.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps
+PS> Install-Module -Name Arcus.Scripting.DevOps --MinimumVersion 0.2.0
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault --MaximumVersion 0.2.0
+PS> Install-Module -Name Arcus.Scripting.KeyVault --RequiredVersion 0.2.0
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault
+PS> Install-Module -Name Arcus.Scripting.KeyVault --MinimumVersion 0.2.0
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault --MinimumVersion 0.2.0
+PS> Install-Module -Name Arcus.Scripting.KeyVault --MaximumVersion 0.2.0
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-logic-apps.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps --MinimumVersion 0.2.0
+PS> Install-Module -Name Arcus.Scripting.LogicApps --MaximumVersion 0.2.0
 ```
 
 ## Disabling Azure Logic Apps from configuration file

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-logic-apps.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps --MaximumVersion 0.2.0
+PS> Install-Module -Name Arcus.Scripting.LogicApps --RequiredVersion 0.2.0
 ```
 
 ## Disabling Azure Logic Apps from configuration file

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-logic-apps.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps
+PS> Install-Module -Name Arcus.Scripting.LogicApps --MinimumVersion 0.2.0
 ```
 
 ## Disabling Azure Logic Apps from configuration file

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-storage.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-storage.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table
+PS> Install-Module -Name Arcus.Scripting.Storage.Table --MinimumVersion 0.2.0
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-storage.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-storage.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table --MinimumVersion 0.2.0
+PS> Install-Module -Name Arcus.Scripting.Storage.Table --MaximumVersion 0.2.0
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-storage.md
+++ b/docs/versioned_docs/version-v0.2/02-Features/powershell/azure-storage.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table --MaximumVersion 0.2.0
+PS> Install-Module -Name Arcus.Scripting.Storage.Table --RequiredVersion 0.2.0
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.3/01-index.md
+++ b/docs/versioned_docs/version-v0.3/01-index.md
@@ -5,15 +5,13 @@ slug: /
 sidebar_label: Welcome
 ---
 
-[![PowerShell Gallery Version](https://img.shields.io/badge/powershell%20gallery-v0.3.0-orange)](https://www.powershellgallery.com/packages/Arcus.Scripting.ARM/0.3.0)
-
 # Installation
 
 The Arcus.Scripting modules can be found on the PowerShell gallery.
 Install the latest version of a module by executing the following command:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -Version 0.3.0
+PS> Install-Module -Name Arcus.Scripting.ARM -MinimumVersion 0.3.0
 ```
 
 For more granular packages we recommend reading the documentation.

--- a/docs/versioned_docs/version-v0.3/01-index.md
+++ b/docs/versioned_docs/version-v0.3/01-index.md
@@ -11,7 +11,7 @@ The Arcus.Scripting modules can be found on the PowerShell gallery.
 Install the latest version of a module by executing the following command:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -MaximumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.ARM -RequiredVersion 0.3.0
 ```
 
 For more granular packages we recommend reading the documentation.

--- a/docs/versioned_docs/version-v0.3/01-index.md
+++ b/docs/versioned_docs/version-v0.3/01-index.md
@@ -11,7 +11,7 @@ The Arcus.Scripting modules can be found on the PowerShell gallery.
 Install the latest version of a module by executing the following command:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -MinimumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.ARM -MaximumVersion 0.3.0
 ```
 
 For more granular packages we recommend reading the documentation.

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -MinimumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.ARM -MaximumVersion 0.3.0
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -MaximumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.ARM -RequiredVersion 0.3.0
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM
+PS> Install-Module -Name Arcus.Scripting.ARM -MinimumVersion 0.3.0
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-api-management.md
@@ -20,7 +20,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -MinimumVersion 0.3.0
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-api-management.md
@@ -20,7 +20,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement -MaximumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -RequiredVersion 0.3.0
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-api-management.md
@@ -20,7 +20,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement -MinimumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -MaximumVersion 0.3.0
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory
+PS> Install-Module -Name Arcus.Scripting.DataFactory -MinimumVersion 0.3.0
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory -MaximumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.DataFactory -RequiredVersion 0.3.0
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory -MinimumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.DataFactory -MaximumVersion 0.3.0
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-devops.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps
+PS> Install-Module -Name Arcus.Scripting.DevOps -MinimumVersion 0.3.0
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-devops.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps -MaximumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.DevOps -RequiredVersion 0.3.0
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-devops.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps -MinimumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.DevOps -MaximumVersion 0.3.0
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault
+PS> Install-Module -Name Arcus.Scripting.KeyVault -MinimumVersion 0.3.0
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault -MinimumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.KeyVault -MaximumVersion 0.3.0
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault -MaximumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.KeyVault -RequiredVersion 0.3.0
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-logic-apps.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps
+PS> Install-Module -Name Arcus.Scripting.LogicApps -MinimumVersion 0.3.0
 ```
 
 ## Disable an Azure Logic App

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-logic-apps.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps -MaximumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.LogicApps -RequiredVersion 0.3.0
 ```
 
 ## Disable an Azure Logic App

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-logic-apps.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps -MinimumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.LogicApps -MaximumVersion 0.3.0
 ```
 
 ## Disable an Azure Logic App

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-security.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-security.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Security
+PS> Import-Module -Name Arcus.Scripting.Security -MinimumVersion 0.3.0
 ```
 
 ## Removing resource locks from an Azure resource group

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-security.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-security.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Security -MaximumVersion 0.3.0
+PS> Import-Module -Name Arcus.Scripting.Security -RequiredVersion 0.3.0
 ```
 
 ## Removing resource locks from an Azure resource group

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-security.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-security.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Security -MinimumVersion 0.3.0
+PS> Import-Module -Name Arcus.Scripting.Security -MaximumVersion 0.3.0
 ```
 
 ## Removing resource locks from an Azure resource group

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-blob.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-blob.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MaximumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.Storage.Blob -RequiredVersion 0.3.0
 ```
 
 ## Uploading files to a Azure Storage Blob container

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-blob.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-blob.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MinimumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MaximumVersion 0.3.0
 ```
 
 ## Uploading files to a Azure Storage Blob container

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-blob.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-blob.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Blob
+PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MinimumVersion 0.3.0
 ```
 
 ## Uploading files to a Azure Storage Blob container

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-fileshare.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-fileshare.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.FileShare
+PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MinimumVersion 0.3.0
 ```
 
 ## Creating a folder on an Azure file share

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-fileshare.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-fileshare.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MinimumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MaximumVersion 0.3.0
 ```
 
 ## Creating a folder on an Azure file share

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-fileshare.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-fileshare.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MaximumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -RequiredVersion 0.3.0
 ```
 
 ## Creating a folder on an Azure file share

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-table.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-table.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -MinimumVersion 0.3.0
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-table.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-table.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table -MaximumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -RequiredVersion 0.3.0
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-table.md
+++ b/docs/versioned_docs/version-v0.3/02-Features/powershell/azure-storage/azure-storage-table.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table -MinimumVersion 0.3.0
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -MaximumVersion 0.3.0
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.4.3/01-index.md
+++ b/docs/versioned_docs/version-v0.4.3/01-index.md
@@ -13,7 +13,7 @@ The Arcus.Scripting modules can be found on the PowerShell gallery.
 Install the latest version of a module by executing the following command:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.All --Version 0.4.3
+PS> Install-Module -Name Arcus.Scripting.All -MinimumVersion 0.4.3
 ```
 
 For more granular packages we recommend reading the documentation.

--- a/docs/versioned_docs/version-v0.4.3/01-index.md
+++ b/docs/versioned_docs/version-v0.4.3/01-index.md
@@ -11,7 +11,7 @@ The Arcus.Scripting modules can be found on the PowerShell gallery.
 Install the latest version of a module by executing the following command:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.All -MinimumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.All -MaximumVersion 0.4.3
 ```
 
 For more granular packages we recommend reading the documentation.

--- a/docs/versioned_docs/version-v0.4.3/01-index.md
+++ b/docs/versioned_docs/version-v0.4.3/01-index.md
@@ -11,7 +11,7 @@ The Arcus.Scripting modules can be found on the PowerShell gallery.
 Install the latest version of a module by executing the following command:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.All -MaximumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.All -RequiredVersion 0.4.3
 ```
 
 For more granular packages we recommend reading the documentation.

--- a/docs/versioned_docs/version-v0.4.3/01-index.md
+++ b/docs/versioned_docs/version-v0.4.3/01-index.md
@@ -5,8 +5,6 @@ slug: /
 sidebar_label: Welcome
 ---
 
-[![PowerShell Gallery Version](https://img.shields.io/badge/powershell%20gallery-v0.4.3-orange)](https://www.powershellgallery.com/packages/Arcus.Scripting.All/0.4.3)
-
 # Installation
 
 The Arcus.Scripting modules can be found on the PowerShell gallery.

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -MaximumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.ARM -RequiredVersion 0.4.3
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM
+PS> Install-Module -Name Arcus.Scripting.ARM -MinimumVersion 0.4.3
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -MinimumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.ARM -MaximumVersion 0.4.3
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-api-management.md
@@ -22,7 +22,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement -MaximumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -RequiredVersion 0.4.3
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-api-management.md
@@ -22,7 +22,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement -MinimumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -MaximumVersion 0.4.3
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-api-management.md
@@ -22,7 +22,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -MinimumVersion 0.4.3
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory -MaximumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.DataFactory -RequiredVersion 0.4.3
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory
+PS> Install-Module -Name Arcus.Scripting.DataFactory -MinimumVersion 0.4.3
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory -MinimumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.DataFactory -MaximumVersion 0.4.3
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-devops.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps -MaximumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.DevOps -RequiredVersion 0.4.3
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-devops.md
@@ -6,7 +6,6 @@ layout: default
 # Azure DevOps
 
 This module provides the following capabilities:
-- [Installation](#installation)
 - [Setting a variable in an Azure DevOps pipeline](#setting-a-variable-in-an-azure-devops-pipeline)
 - [Setting ARM outputs to Azure DevOps variable group](#setting-arm-outputs-to-azure-devops-variable-group)
 - [Setting ARM outputs to Azure DevOps pipeline variables](#setting-arm-outputs-to-azure-devops-pipeline-variables)
@@ -16,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps
+PS> Install-Module -Name Arcus.Scripting.DevOps -MinimumVersion 0.4.3
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-devops.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps -MinimumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.DevOps -MaximumVersion 0.4.3
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault -MinimumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.KeyVault -MaximumVersion 0.4.3
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault -MaximumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.KeyVault -RequiredVersion 0.4.3
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault
+PS> Install-Module -Name Arcus.Scripting.KeyVault -MinimumVersion 0.4.3
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-logic-apps.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps
+PS> Install-Module -Name Arcus.Scripting.LogicApps -MinimumVersion 0.4.3
 ```
 
 ## Disable an Azure Logic App

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-logic-apps.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps -MaximumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.LogicApps -RequiredVersion 0.4.3
 ```
 
 ## Disable an Azure Logic App

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-logic-apps.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps -MinimumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.LogicApps -MaximumVersion 0.4.3
 ```
 
 ## Disable an Azure Logic App

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-security.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-security.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Security -MaximumVersion 0.4.3
+PS> Import-Module -Name Arcus.Scripting.Security -RequiredVersion 0.4.3
 ```
 
 ## Removing resource locks from an Azure resource group

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-security.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-security.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Security
+PS> Import-Module -Name Arcus.Scripting.Security -MinimumVersion 0.4.3
 ```
 
 ## Removing resource locks from an Azure resource group

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-security.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-security.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Security -MinimumVersion 0.4.3
+PS> Import-Module -Name Arcus.Scripting.Security -MaximumVersion 0.4.3
 ```
 
 ## Removing resource locks from an Azure resource group

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-sql.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-sql.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.SQL -MinimumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.SQL -MaximumVersion 0.4.3
 ```
 
 ## Invoke a database migration

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-sql.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-sql.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.SQL -MaximumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.SQL -RequiredVersion 0.4.3
 ```
 
 ## Invoke a database migration

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-sql.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-sql.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.SQL
+PS> Install-Module -Name Arcus.Scripting.SQL -MinimumVersion 0.4.3
 ```
 
 ## Invoke a database migration

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-all.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-all.md
@@ -13,7 +13,7 @@ This module contains several sub-modules, all related to Azure Storage.
 Install all Azure Storage-related modules at once via:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.All -MaximumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.Storage.All -RequiredVersion 0.4.3
 ```
 
 ## Azure Table Storage

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-all.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-all.md
@@ -13,7 +13,7 @@ This module contains several sub-modules, all related to Azure Storage.
 Install all Azure Storage-related modules at once via:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.All -MinimumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.Storage.All -MaximumVersion 0.4.3
 ```
 
 ## Azure Table Storage

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-all.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-all.md
@@ -13,7 +13,7 @@ This module contains several sub-modules, all related to Azure Storage.
 Install all Azure Storage-related modules at once via:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.All
+PS> Install-Module -Name Arcus.Scripting.Storage.All -MinimumVersion 0.4.3
 ```
 
 ## Azure Table Storage

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-blob.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-blob.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MaximumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.Storage.Blob -RequiredVersion 0.4.3
 ```
 
 ## Uploading files to a Azure Storage Blob container

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-blob.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-blob.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MinimumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MaximumVersion 0.4.3
 ```
 
 ## Uploading files to a Azure Storage Blob container

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-blob.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-blob.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Blob
+PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MinimumVersion 0.4.3
 ```
 
 ## Uploading files to a Azure Storage Blob container

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-fileshare.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-fileshare.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MaximumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -RequiredVersion 0.4.3
 ```
 
 ## Creating a folder on an Azure file share

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-fileshare.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-fileshare.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.FileShare
+PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MinimumVersion 0.4.3
 ```
 
 ## Creating a folder on an Azure file share

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-fileshare.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-fileshare.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MinimumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MaximumVersion 0.4.3
 ```
 
 ## Creating a folder on an Azure file share

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-table.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-table.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -MinimumVersion 0.4.3
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-table.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-table.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table -MaximumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -RequiredVersion 0.4.3
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-table.md
+++ b/docs/versioned_docs/version-v0.4.3/02-Features/powershell/azure-storage/azure-storage-table.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table -MinimumVersion 0.4.3
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -MaximumVersion 0.4.3
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.4/01-index.md
+++ b/docs/versioned_docs/version-v0.4/01-index.md
@@ -11,7 +11,7 @@ The Arcus.Scripting modules can be found on the PowerShell gallery.
 Install the latest version of a module by executing the following command:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.All -MaximumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.All -RequiredVersion 0.4.0
 ```
 
 For more granular packages we recommend reading the documentation.

--- a/docs/versioned_docs/version-v0.4/01-index.md
+++ b/docs/versioned_docs/version-v0.4/01-index.md
@@ -5,15 +5,13 @@ slug: /
 sidebar_label: Welcome
 ---
 
-[![PowerShell Gallery Version](https://img.shields.io/badge/powershell%20gallery-v0.4.0-orange)](https://www.powershellgallery.com/packages/Arcus.Scripting.All/0.4.0)
-
 # Installation
 
 The Arcus.Scripting modules can be found on the PowerShell gallery.
 Install the latest version of a module by executing the following command:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.All --Version 0.4.0
+PS> Install-Module -Name Arcus.Scripting.All -MinimumVersion 0.4.0
 ```
 
 For more granular packages we recommend reading the documentation.

--- a/docs/versioned_docs/version-v0.4/01-index.md
+++ b/docs/versioned_docs/version-v0.4/01-index.md
@@ -11,7 +11,7 @@ The Arcus.Scripting modules can be found on the PowerShell gallery.
 Install the latest version of a module by executing the following command:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.All -MinimumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.All -MaximumVersion 0.4.0
 ```
 
 For more granular packages we recommend reading the documentation.

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -MinimumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.ARM -MaximumVersion 0.4.0
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM
+PS> Install-Module -Name Arcus.Scripting.ARM -MinimumVersion 0.4.0
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -MaximumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.ARM -RequiredVersion 0.4.0
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-api-management.md
@@ -20,7 +20,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement -MaximumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -RequiredVersion 0.4.0
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-api-management.md
@@ -20,7 +20,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement -MinimumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -MaximumVersion 0.4.0
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-api-management.md
@@ -20,7 +20,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -MinimumVersion 0.4.0
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory -MinimumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.DataFactory -MaximumVersion 0.4.0
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory
+PS> Install-Module -Name Arcus.Scripting.DataFactory -MinimumVersion 0.4.0
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory -MaximumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.DataFactory -RequiredVersion 0.4.0
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-devops.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps -MaximumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.DevOps -RequiredVersion 0.4.0
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-devops.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps -MinimumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.DevOps -MaximumVersion 0.4.0
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-devops.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps
+PS> Install-Module -Name Arcus.Scripting.DevOps -MinimumVersion 0.4.0
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault -MinimumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.KeyVault -MaximumVersion 0.4.0
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault -MaximumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.KeyVault -RequiredVersion 0.4.0
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault
+PS> Install-Module -Name Arcus.Scripting.KeyVault -MinimumVersion 0.4.0
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-logic-apps.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps
+PS> Install-Module -Name Arcus.Scripting.LogicApps -MinimumVersion 0.4.0
 ```
 
 ## Disable an Azure Logic App

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-logic-apps.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps -MinimumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.LogicApps -MaximumVersion 0.4.0
 ```
 
 ## Disable an Azure Logic App

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-logic-apps.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps -MaximumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.LogicApps -RequiredVersion 0.4.0
 ```
 
 ## Disable an Azure Logic App

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-security.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-security.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Security -MaximumVersion 0.4.0
+PS> Import-Module -Name Arcus.Scripting.Security -RequiredVersion 0.4.0
 ```
 
 ## Removing resource locks from an Azure resource group

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-security.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-security.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Security -MinimumVersion 0.4.0
+PS> Import-Module -Name Arcus.Scripting.Security -MaximumVersion 0.4.0
 ```
 
 ## Removing resource locks from an Azure resource group

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-security.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-security.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Security
+PS> Import-Module -Name Arcus.Scripting.Security -MinimumVersion 0.4.0
 ```
 
 ## Removing resource locks from an Azure resource group

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-sql.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-sql.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.SQL
+PS> Install-Module -Name Arcus.Scripting.SQL -MinimumVersion 0.4.0
 ```
 
 ## Invoke a database migration

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-sql.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-sql.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.SQL -MaximumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.SQL -RequiredVersion 0.4.0
 ```
 
 ## Invoke a database migration

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-sql.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-sql.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.SQL -MinimumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.SQL -MaximumVersion 0.4.0
 ```
 
 ## Invoke a database migration

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-all.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-all.md
@@ -13,7 +13,7 @@ This module contains several sub-modules, all related to Azure Storage.
 Install all Azure Storage-related modules at once via:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.All -MaximumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.Storage.All -RequiredVersion 0.4.0
 ```
 
 ## Azure Table Storage

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-all.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-all.md
@@ -13,7 +13,7 @@ This module contains several sub-modules, all related to Azure Storage.
 Install all Azure Storage-related modules at once via:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.All -MinimumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.Storage.All -MaximumVersion 0.4.0
 ```
 
 ## Azure Table Storage

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-all.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-all.md
@@ -13,7 +13,7 @@ This module contains several sub-modules, all related to Azure Storage.
 Install all Azure Storage-related modules at once via:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.All
+PS> Install-Module -Name Arcus.Scripting.Storage.All -MinimumVersion 0.4.0
 ```
 
 ## Azure Table Storage

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-blob.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-blob.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Blob
+PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MinimumVersion 0.4.0
 ```
 
 ## Uploading files to a Azure Storage Blob container

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-blob.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-blob.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MaximumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.Storage.Blob -RequiredVersion 0.4.0
 ```
 
 ## Uploading files to a Azure Storage Blob container

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-blob.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-blob.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MinimumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MaximumVersion 0.4.0
 ```
 
 ## Uploading files to a Azure Storage Blob container

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-fileshare.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-fileshare.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MinimumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MaximumVersion 0.4.0
 ```
 
 ## Creating a folder on an Azure file share

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-fileshare.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-fileshare.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.FileShare
+PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MinimumVersion 0.4.0
 ```
 
 ## Creating a folder on an Azure file share

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-fileshare.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-fileshare.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MaximumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -RequiredVersion 0.4.0
 ```
 
 ## Creating a folder on an Azure file share

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-table.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-table.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table -MaximumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -RequiredVersion 0.4.0
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-table.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-table.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -MinimumVersion 0.4.0
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-table.md
+++ b/docs/versioned_docs/version-v0.4/02-Features/powershell/azure-storage/azure-storage-table.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table -MinimumVersion 0.4.0
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -MaximumVersion 0.4.0
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.5/01-index.md
+++ b/docs/versioned_docs/version-v0.5/01-index.md
@@ -5,8 +5,6 @@ slug: /
 sidebar_label: Welcome
 ---
 
-![PowerShell Gallery Version](https://img.shields.io/powershellgallery/v/Arcus.Scripting.All)
-
 # Installation
 
 The Arcus.Scripting modules can be found on the PowerShell gallery.

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -MinimumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.ARM -MaximumVersion 0.5.0
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM -MaximumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.ARM -RequiredVersion 0.5.0
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/arm.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/arm.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ARM
+PS> Install-Module -Name Arcus.Scripting.ARM -MinimumVersion 0.5.0
 ```
 
 ## Injecting content into an ARM template

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-api-management.md
@@ -21,7 +21,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement -MinimumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -MaximumVersion 0.5.0
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-api-management.md
@@ -21,7 +21,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -MinimumVersion 0.5.0
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-api-management.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-api-management.md
@@ -21,7 +21,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.ApiManagement -MaximumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.ApiManagement -RequiredVersion 0.5.0
 ```
 
 ## Backing up an API Management service

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory -MaximumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.DataFactory -RequiredVersion 0.5.0
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory
+PS> Install-Module -Name Arcus.Scripting.DataFactory -MinimumVersion 0.5.0
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-data-factory.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-data-factory.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DataFactory -MinimumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.DataFactory -MaximumVersion 0.5.0
 ```
 
 ## Enabling a trigger of an Azure Data Factory pipeline

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-devops.md
@@ -18,7 +18,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps
+PS> Install-Module -Name Arcus.Scripting.DevOps -MinimumVersion 0.5.0
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-devops.md
@@ -18,7 +18,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps -MaximumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.DevOps -RequiredVersion 0.5.0
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-devops.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-devops.md
@@ -18,7 +18,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps -MinimumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.DevOps -MaximumVersion 0.5.0
 ```
 
 ## Setting a variable in an Azure DevOps pipeline

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-integration-account.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-integration-account.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.IntegrationAccount -MaximumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.IntegrationAccount -RequiredVersion 0.5.0
 ```
 
 ## Uploading schemas into an Azure Integration Account

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-integration-account.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-integration-account.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.IntegrationAccount -MinimumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.IntegrationAccount -MaximumVersion 0.5.0
 ```
 
 ## Uploading schemas into an Azure Integration Account

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-integration-account.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-integration-account.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.IntegrationAccount
+PS> Install-Module -Name Arcus.Scripting.IntegrationAccount -MinimumVersion 0.5.0
 ```
 
 ## Uploading schemas into an Azure Integration Account

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault
+PS> Install-Module -Name Arcus.Scripting.KeyVault -MinimumVersion 0.5.0
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault -MinimumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.KeyVault -MaximumVersion 0.5.0
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-key-vault.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-key-vault.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.KeyVault -MaximumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.KeyVault -RequiredVersion 0.5.0
 ```
 
 ## Getting all access policies for an Azure Key Vault

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-logic-apps.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps -MaximumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.LogicApps -RequiredVersion 0.5.0
 ```
 
 ## Disable an Azure Logic App

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-logic-apps.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps -MinimumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.LogicApps -MaximumVersion 0.5.0
 ```
 
 ## Disable an Azure Logic App

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-logic-apps.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-logic-apps.md
@@ -16,7 +16,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.LogicApps
+PS> Install-Module -Name Arcus.Scripting.LogicApps -MinimumVersion 0.5.0
 ```
 
 ## Disable an Azure Logic App

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-security.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-security.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Security
+PS> Import-Module -Name Arcus.Scripting.Security -MinimumVersion 0.5.0
 ```
 
 ## Removing resource locks from an Azure resource group

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-security.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-security.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Security -MinimumVersion 0.5.0
+PS> Import-Module -Name Arcus.Scripting.Security -MaximumVersion 0.5.0
 ```
 
 ## Removing resource locks from an Azure resource group

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-security.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-security.md
@@ -15,7 +15,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Import-Module -Name Arcus.Scripting.Security -MaximumVersion 0.5.0
+PS> Import-Module -Name Arcus.Scripting.Security -RequiredVersion 0.5.0
 ```
 
 ## Removing resource locks from an Azure resource group

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-sql.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-sql.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.SQL -MinimumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.SQL -MaximumVersion 0.5.0
 ```
 
 ## Invoke a database migration

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-sql.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-sql.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.SQL -MaximumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.SQL -RequiredVersion 0.5.0
 ```
 
 ## Invoke a database migration

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-sql.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-sql.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.SQL
+PS> Install-Module -Name Arcus.Scripting.SQL -MinimumVersion 0.5.0
 ```
 
 ## Invoke a database migration

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-all.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-all.md
@@ -13,7 +13,7 @@ This module contains several sub-modules, all related to Azure Storage.
 Install all Azure Storage-related modules at once via:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.All -MinimumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.Storage.All -MaximumVersion 0.5.0
 ```
 
 ## Azure Table Storage

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-all.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-all.md
@@ -13,7 +13,7 @@ This module contains several sub-modules, all related to Azure Storage.
 Install all Azure Storage-related modules at once via:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.All -MaximumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.Storage.All -RequiredVersion 0.5.0
 ```
 
 ## Azure Table Storage

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-all.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-all.md
@@ -13,7 +13,7 @@ This module contains several sub-modules, all related to Azure Storage.
 Install all Azure Storage-related modules at once via:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.All
+PS> Install-Module -Name Arcus.Scripting.Storage.All -MinimumVersion 0.5.0
 ```
 
 ## Azure Table Storage

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-blob.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-blob.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MinimumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MaximumVersion 0.5.0
 ```
 
 ## Uploading files to a Azure Storage Blob container

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-blob.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-blob.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MaximumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.Storage.Blob -RequiredVersion 0.5.0
 ```
 
 ## Uploading files to a Azure Storage Blob container

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-blob.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-blob.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Blob
+PS> Install-Module -Name Arcus.Scripting.Storage.Blob -MinimumVersion 0.5.0
 ```
 
 ## Uploading files to a Azure Storage Blob container

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-fileshare.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-fileshare.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MaximumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -RequiredVersion 0.5.0
 ```
 
 ## Creating a folder on an Azure file share

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-fileshare.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-fileshare.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.FileShare
+PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MinimumVersion 0.5.0
 ```
 
 ## Creating a folder on an Azure file share

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-fileshare.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-fileshare.md
@@ -14,7 +14,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MinimumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.Storage.FileShare -MaximumVersion 0.5.0
 ```
 
 ## Creating a folder on an Azure file share

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-table.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-table.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table -MinimumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -MaximumVersion 0.5.0
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-table.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-table.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -MinimumVersion 0.5.0
 ```
 
 ## Creating a new table in an Azure Storage Account

--- a/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-table.md
+++ b/docs/versioned_docs/version-v0.5/02-Features/powershell/azure-storage/azure-storage-table.md
@@ -13,7 +13,7 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.Storage.Table -MaximumVersion 0.5.0
+PS> Install-Module -Name Arcus.Scripting.Storage.Table -RequiredVersion 0.5.0
 ```
 
 ## Creating a new table in an Azure Storage Account


### PR DESCRIPTION
Add `-MaximumVersion` to `Install-Module` commands to be in line with the other Arcus docs, and not to wrongly guide consumers to the wrong version.