### PR TITLE
fix: make sure the variable group description uses a releasename when using YAML pipelines

### DIFF
--- a/src/Arcus.Scripting.DevOps/Scripts/Set-AzDevOpsArmOutputs.ps1
+++ b/src/Arcus.Scripting.DevOps/Scripts/Set-AzDevOpsArmOutputs.ps1
@@ -40,13 +40,18 @@ function Add-VariableGroupVariable()
         Write-Host Get variable group
         $getVariableGroupUrl= $projectUri + $project + "/_apis/distributedtask/variablegroups?api-version=" + $apiVersion + "&groupName=" + $VariableGroupName
         $variableGroup = (Invoke-RestMethod -Uri $getVariableGroupUrl -Headers $headers -Verbose) 
+        $releaseName = $env:Release_ReleaseName
+        if ([string]::IsNullOrEmpty($releaseName))
+        {
+            $releaseName = $env:Build_DefinitionName + " " + $env:Build_BuildNumber
+        }
         
         if($variableGroup.value)
         {
             #Set properties for update of existing variable group
             Write-Host Set properties for update of existing variable group
             $variableGroup = $variableGroup.value[0]
-			$variableGroup | Add-Member -Name "description" -MemberType NoteProperty -Value "Variable group that got auto-updated by release '$env:Release_ReleaseName'." -Force
+			$variableGroup | Add-Member -Name "description" -MemberType NoteProperty -Value "Variable group that got auto-updated by release '$releaseName'." -Force
             $method = "Put"
             $upsertVariableGroupUrl = $projectUri + $project + "/_apis/distributedtask/variablegroups/" + $variableGroup.id + "?api-version=" + $apiVersion    
         }
@@ -54,7 +59,7 @@ function Add-VariableGroupVariable()
         {
             #Set properties for creation of new variable group
             Write-Host Set properties for creation of new variable group
-            $variableGroup = @{name=$VariableGroupName;type="Vsts";description="Variable group that got auto-updated by release '$env:Release_ReleaseName'.";variables=New-Object PSObject;}
+            $variableGroup = @{name=$VariableGroupName;type="Vsts";description="Variable group that got auto-updated by release '$releaseName'.";variables=New-Object PSObject;}
             $method = "Post"
             $upsertVariableGroupUrl = $projectUri + $project + "/_apis/distributedtask/variablegroups?api-version=" + $apiVersion
         }

--- a/src/Arcus.Scripting.DevOps/Scripts/Set-AzDevOpsArmOutputs.ps1
+++ b/src/Arcus.Scripting.DevOps/Scripts/Set-AzDevOpsArmOutputs.ps1
@@ -40,10 +40,10 @@ function Add-VariableGroupVariable()
         Write-Host Get variable group
         $getVariableGroupUrl= $projectUri + $project + "/_apis/distributedtask/variablegroups?api-version=" + $apiVersion + "&groupName=" + $VariableGroupName
         $variableGroup = (Invoke-RestMethod -Uri $getVariableGroupUrl -Headers $headers -Verbose) 
-        $releaseName = $env:Release_ReleaseName
+        $releaseName = $env:RELEASE_RELEASENAME
         if ([string]::IsNullOrEmpty($releaseName))
         {
-            $releaseName = $env:Build_DefinitionName + " " + $env:Build_BuildNumber
+            $releaseName = $env:BUILD_DEFINITIONNAME + " " + $env:BUILD_BUILDNUMBER
         }
         
         if($variableGroup.value)

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -32,23 +32,23 @@ InModuleScope Arcus.Scripting.DevOps {
                     $patchResponse.StatusCode | Should -Be 200
                 }
             }
-            #It "Sets the DevOps variable group description with the release name" {
-            #    # Arrange
-            #    $variableGroupName = $config.Arcus.DevOps.VariableGroup.Name
-            #    $env:ArmOutputs = "{ ""my-variable"": { ""type"": ""string"", ""value"": ""my-value"" } }"
-            #    $projectId = $env:SYSTEM_TEAMPROJECTID                
-            #    $collectionUri = $env:SYSTEM_COLLECTIONURI
-            #    $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=/" + $variableGroupName + "?api-version=6.0"
-            #    $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
+            It "Sets the DevOps variable group description with the release name" -Skip {
+                # Arrange
+                $variableGroupName = $config.Arcus.DevOps.VariableGroup.Name
+                $env:ArmOutputs = "{ ""my-variable"": { ""type"": ""string"", ""value"": ""my-value"" } }"
+                $projectId = $env:SYSTEM_TEAMPROJECTID                
+                $collectionUri = $env:SYSTEM_COLLECTIONURI
+                $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=/" + $variableGroupName + "?api-version=6.0"
+                $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
 
-            #    # Act
-            #    Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName $variableGroupName
+                # Act
+                Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName $variableGroupName
 
-            #    # Assert
-            #    $getResponse = Invoke-WebRequest -Uri $requestUri -Method Get -Headers $headers
-            #    $json = ConvertFrom-Json $getResponse.Content
-            #    $json.description | Should -BeLike "*$env:Build_DefinitionName*$env:Build_BuildNumber*"
-            #}
+                # Assert
+                $getResponse = Invoke-WebRequest -Uri $requestUri -Method Get -Headers $headers
+                $json = ConvertFrom-Json $getResponse.Content
+                $json.description | Should -BeLike "*$env:Build_DefinitionName*$env:Build_BuildNumber*"
+            }
         }
     }
 }

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -35,7 +35,7 @@ InModuleScope Arcus.Scripting.DevOps {
             It "Sets the DevOps variable group description with the release name" {
                 # Arrange
                 $variableGroupName = $config.Arcus.DevOps.VariableGroup.Name
-                $env:ArmOutputs = "{ ""$variableGroupName"": [ { ""Name"": ""my-variable"", ""Value"": { ""value"": ""my-value"" } } ] }"
+                $env:ArmOutputs = "{ ""my-variable"": { ""type"": ""string"", ""value"": ""my-value"" } }"
                 $projectId = $env:SYSTEM_TEAMPROJECTID                
                 $collectionUri = $env:SYSTEM_COLLECTIONURI
                 $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=/" + $variableGroupName + "?api-version=6.0"

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -32,23 +32,23 @@ InModuleScope Arcus.Scripting.DevOps {
                     $patchResponse.StatusCode | Should -Be 200
                 }
             }
-            It "Sets the DevOps variable group description with the release name" {
-                # Arrange
-                $variableGroupName = $config.Arcus.DevOps.VariableGroup.Name
-                $env:ArmOutputs = "{ ""my-variable"": { ""type"": ""string"", ""value"": ""my-value"" } }"
-                $projectId = $env:SYSTEM_TEAMPROJECTID                
-                $collectionUri = $env:SYSTEM_COLLECTIONURI
-                $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=/" + $variableGroupName + "?api-version=6.0"
-                $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
+            #It "Sets the DevOps variable group description with the release name" {
+            #    # Arrange
+            #    $variableGroupName = $config.Arcus.DevOps.VariableGroup.Name
+            #    $env:ArmOutputs = "{ ""my-variable"": { ""type"": ""string"", ""value"": ""my-value"" } }"
+            #    $projectId = $env:SYSTEM_TEAMPROJECTID                
+            #    $collectionUri = $env:SYSTEM_COLLECTIONURI
+            #    $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=/" + $variableGroupName + "?api-version=6.0"
+            #    $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
 
-                # Act
-                Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName $variableGroupName
+            #    # Act
+            #    Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName $variableGroupName
 
-                # Assert
-                $getResponse = Invoke-WebRequest -Uri $requestUri -Method Get -Headers $headers
-                $json = ConvertFrom-Json $getResponse.Content
-                $json.description | Should -BeLike "*$env:Build_DefinitionName*$env:Build_BuildNumber*"
-            }
+            #    # Assert
+            #    $getResponse = Invoke-WebRequest -Uri $requestUri -Method Get -Headers $headers
+            #    $json = ConvertFrom-Json $getResponse.Content
+            #    $json.description | Should -BeLike "*$env:Build_DefinitionName*$env:Build_BuildNumber*"
+            #}
         }
     }
 }

--- a/src/Arcus.Scripting.Tests.Integration/appsettings.json
+++ b/src/Arcus.Scripting.Tests.Integration/appsettings.json
@@ -1,11 +1,16 @@
 {
   "Arcus": {
-    "SubscriptionId": "#{Arcus.SubscriptionId}#", 
+    "SubscriptionId": "#{Arcus.SubscriptionId}#",
     "TenantId": "#{Arcus.TenantId}#",
     "ResourceGroupName": "#{Arcus.ResourceGroupName}#",
     "ServicePrincipal": {
       "ClientId": "#{Arcus.ServicePrincipal.ClientId}#",
       "ClientSecret": "#{Arcus.ServicePrincipal.ClientSecret}#"
+    },
+    "DevOps": {
+      "VariableGroup": {
+        "Name": "#{Arcus.DevOps.VariableGroup.Name}#"
+      }
     },
     "KeyVault": {
       "VaultName": "#{Arcus.KeyVault.VaultName}#"

--- a/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.DevOps.tests.ps1
@@ -99,7 +99,7 @@ Describe "Arcus" {
                 $variableGroupName = "some-variable-group-name"
                 $env:ArmOutputs = "{ ""$variableGroupName"": [ { ""Name"": ""my-variable"", ""Value"": { ""value"": ""my-value"" } } ] }"
                 $env:SYSTEM_ACCESSTOKEN = "something to fill"
-                $env:Release_ReleaseName = "release 1.0"
+                $env:RELEASE_RELEASENAME = "release 1.0"
                 
                 $variableName = "some-id"
 
@@ -126,8 +126,8 @@ Describe "Arcus" {
                 $variableGroupName = "some-variable-group-name"
                 $env:ArmOutputs = "{ ""$variableGroupName"": [ { ""Name"": ""my-variable"", ""Value"": { ""value"": ""my-value"" } } ] }"
                 $env:SYSTEM_ACCESSTOKEN = "something to fill"
-                $env:Build_DefinitionName = "release"
-                $env:Build_BuildNumber = "1.0"
+                $env:BUILD_DEFINITIONNAME = "release"
+                $env:BUILD_BUILDNUMBER = "1.0"
                 
                 $variableName = "some-id"
 

--- a/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.DevOps.tests.ps1
@@ -107,7 +107,7 @@ Describe "Arcus" {
                     if ($Method -eq "Post" -or $Method -eq "Put") {
                         $Uri | Should -BeLike "*$variableGroupName*"
                         $Body | Should -BeLike "*$variableName*"
-                        $Body | Should -BeLike "*Variable group that got auto-updated by release \u0027release 1.0\u0027*"
+                        $Body | Should -BeLike "*release 1.0*"
                         return $null
                     } else {
                         $Uri | Should -BeLike "*$variableGroupName*"
@@ -135,7 +135,7 @@ Describe "Arcus" {
                     if ($Method -eq "Post" -or $Method -eq "Put") {
                         $Uri | Should -BeLike "*$variableGroupName*"
                         $Body | Should -BeLike "*$variableName*"
-                        $Body | Should -BeLike "*Variable group that got auto-updated by release \u0027release 1.0\u0027*"
+                        $Body | Should -BeLike "*release 1.0*"
                         return $null
                     } else {
                         $Uri | Should -BeLike "*$variableGroupName*"

--- a/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.DevOps.tests.ps1
@@ -1,4 +1,6 @@
-﻿Describe "Arcus" {
+﻿Import-Module -Name $PSScriptRoot\..\Arcus.Scripting.DevOps -ErrorAction Stop
+
+Describe "Arcus" {
     Context "Azure DevOps" {
         InModuleScope Arcus.Scripting.DevOps {
             It "Setting DevOps variable should write to host" {
@@ -91,6 +93,61 @@
                 # Assert
                 Assert-VerifiableMock
                 Assert-MockCalled Write-Host
+            }
+            It "Setting DevOps variable group should contain releasename" {
+                # Arrange
+                $variableGroupName = "some-variable-group-name"
+                $env:ArmOutputs = "{ ""$variableGroupName"": [ { ""Name"": ""my-variable"", ""Value"": { ""value"": ""my-value"" } } ] }"
+                $env:SYSTEM_ACCESSTOKEN = "something to fill"
+                $env:Release_ReleaseName = "release 1.0"
+                
+                $variableName = "some-id"
+
+                Mock Invoke-RestMethod {
+                    if ($Method -eq "Post" -or $Method -eq "Put") {
+                        $Uri | Should -BeLike "*$variableGroupName*"
+                        $Body | Should -BeLike "*$variableName*"
+                        $Body | Should -BeLike "*Variable group that got auto-updated by release \u0027release 1.0\u0027*"
+                        return $null
+                    } else {
+                        $Uri | Should -BeLike "*$variableGroupName*"
+                        return [pscustomobject]@{ value = @( [pscustomobject]@{ id = $variableName; variables = [pscustomobject]@{} } ) }
+                    }
+                } -Verifiable
+
+                # Act
+                Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName $variableGroupName
+
+                # Assert
+                Assert-VerifiableMock
+            }
+            It "Setting DevOps variable group should contain releasename when Release.ReleaseName is missing" {
+                # Arrange
+                $variableGroupName = "some-variable-group-name"
+                $env:ArmOutputs = "{ ""$variableGroupName"": [ { ""Name"": ""my-variable"", ""Value"": { ""value"": ""my-value"" } } ] }"
+                $env:SYSTEM_ACCESSTOKEN = "something to fill"
+                $env:Build_DefinitionName = "release"
+                $env:Build_BuildNumber = "1.0"
+                
+                $variableName = "some-id"
+
+                Mock Invoke-RestMethod {
+                    if ($Method -eq "Post" -or $Method -eq "Put") {
+                        $Uri | Should -BeLike "*$variableGroupName*"
+                        $Body | Should -BeLike "*$variableName*"
+                        $Body | Should -BeLike "*Variable group that got auto-updated by release \u0027release 1.0\u0027*"
+                        return $null
+                    } else {
+                        $Uri | Should -BeLike "*$variableGroupName*"
+                        return [pscustomobject]@{ value = @( [pscustomobject]@{ id = $variableName; variables = [pscustomobject]@{} } ) }
+                    }
+                } -Verifiable
+
+                # Act
+                Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName $variableGroupName
+
+                # Assert
+                Assert-VerifiableMock
             }
             It "Setting pipeline variables from default ARM outputs variable writes to output" {
                 # Arrange


### PR DESCRIPTION
When using YAML pipelines the Release.ReleaseName is empty, if this is the case use Build.DefinitionName and Build.BuildNumber and use this as the releasename in the variable group description.

Closes https://github.com/arcus-azure/arcus.scripting/issues/251