### PR TITLE
fix: added redirects for broken links

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -40,6 +40,10 @@ ID = "52a5e73a-fd4e-4d18-8321-5334c5de88c9"
   to = "/:version/features/powershell/azure-storage/azure-storage-table"
 
 [[redirects]]
+  from = "/:version/features/powershell/azure-storage-table"
+  to = "/:version/features/powershell/azure-storage/azure-storage-table"
+
+[[redirects]]
   from = "/features/powershell/azure-storage-all"
   to = "/features/powershell/azure-storage/azure-storage-all"
 
@@ -54,6 +58,10 @@ ID = "52a5e73a-fd4e-4d18-8321-5334c5de88c9"
 [[redirects]]
   from = "/features/powershell/azure-storage-table"
   to = "/features/powershell/azure-storage/azure-storage-table"
+
+[[redirects]]
+from = "/features/powershell/azure-storage"
+to = "/features/powershell/azure-storage/azure-storage-table"
 # Production context: all deploys from the Production branch set in your site's
 # deploy settings will inherit these settings.
 # [context.production]

--- a/netlify.toml
+++ b/netlify.toml
@@ -40,8 +40,12 @@ ID = "52a5e73a-fd4e-4d18-8321-5334c5de88c9"
   to = "/:version/features/powershell/azure-storage/azure-storage-table"
 
 [[redirects]]
-  from = "/:version/features/powershell/azure-storage-table"
+  from = "/:version/features/powershell/azure-storage"
   to = "/:version/features/powershell/azure-storage/azure-storage-table"
+
+[[redirects]]
+from = "/:version/preview/features/powershell/azure-api-management"
+to = "/:version/features/powershell/azure-api-management"
 
 [[redirects]]
   from = "/features/powershell/azure-storage-all"
@@ -62,6 +66,10 @@ ID = "52a5e73a-fd4e-4d18-8321-5334c5de88c9"
 [[redirects]]
 from = "/features/powershell/azure-storage"
 to = "/features/powershell/azure-storage/azure-storage-table"
+
+[[redirects]]
+from = "/preview/features/powershell/azure-api-management"
+to = "/features/powershell/azure-api-management"
 # Production context: all deploys from the Production branch set in your site's
 # deploy settings will inherit these settings.
 # [context.production]


### PR DESCRIPTION
Added redirects for the broken API Management and Azure Storage documentation links.

Closes https://github.com/arcus-azure/arcus.scripting/issues/249 and https://github.com/arcus-azure/arcus.scripting/issues/250