### PR TITLE
feat: remove print "Current access policies: $armAccessPoliciesParameter"

### DIFF
--- a/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
+++ b/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
@@ -44,5 +44,4 @@ $armAccessPoliciesParameter = [pscustomobject]@{
     list = $armAccessPolicies
 }
 
-Write-Host "Current access policies: $armAccessPoliciesParameter"
 return $armAccessPoliciesParameter


### PR DESCRIPTION
Remove print command "Current access policies: $armAccessPoliciesParameter"
on script arcus.scripting\src\Arcus.Scripting.KeyVault\Scripts\Get-AzKeyVaultAccessPolicies.ps1

Closes https://github.com/arcus-azure/arcus.scripting/issues/262