### PR TITLE
chore: use 'resource group' when describing Azure resource groups

### DIFF
--- a/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
+++ b/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
@@ -8,7 +8,7 @@ if($resourceGroupName -eq '') {
     Write-Verbose "Looking for the Azure Key Vault with name '$keyVaultName'..."
     $keyVault = Get-AzKeyVault -VaultName $keyVaultName
 } else {
-    Write-Verbose "Looking for the Azure Key Vault with name '$keyVaultName' in resourcegroup '$resourceGroupName'.."
+    Write-Verbose "Looking for the Azure Key Vault with name '$keyVaultName' in resource group '$resourceGroupName'.."
     $keyVault = Get-AzKeyVault -VaultName $keyVaultName -ResourceGroupName $resourceGroupName
 }
 


### PR DESCRIPTION
Let's maybe use `resource group` instead of `resourcegroup` in our messages.