### PR TITLE
chore: typo 'performing` in disabling Azure LogicApps script

### DIFF
--- a/src/Arcus.Scripting.LogicApps/Scripts/Disable-AzLogicAppsFromConfig.ps1
+++ b/src/Arcus.Scripting.LogicApps/Scripts/Disable-AzLogicAppsFromConfig.ps1
@@ -30,7 +30,7 @@ function ExecuteStopType() {
             }            
         }
         ElseIf ($stopType -Match "None") {
-            Write-Host "Executing Stop 'None' => peforming no stop"
+            Write-Host "Executing Stop 'None' => performing no stop"
         }
         else {
             Write-Warning "StopType '$stopType' has no known implementation, doing nothing.." 


### PR DESCRIPTION
Typo fix `performing` in Azure Logic Apps script for disabling Logic Apps.