### PR TITLE
test: generate integration account certificate key name

### DIFF
--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.IntegrationAccount.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.IntegrationAccount.tests.ps1
@@ -737,7 +737,7 @@ InModuleScope Arcus.Scripting.IntegrationAccount {
                 $expectedCertificateName = $artifactsPrefix + $certificate.BaseName
                 $executionDateTime = (Get-Date).ToUniversalTime()
                 $subscriptionId = $config.Arcus.SubscriptionId
-                $keyName = 'PrivateCertificateKeyPrefix'
+                $keyName = "PrivateCertificateKeyPrefix-$([System.Guid]::NewGuid())"
                 $keyVaultName = $config.Arcus.KeyVault.VaultName
                 $keyVaultId = "/subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.KeyVault/vaults/$keyVaultName"
 

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.IntegrationAccount.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.IntegrationAccount.tests.ps1
@@ -3,7 +3,7 @@ Import-Module -Name $PSScriptRoot\..\Arcus.Scripting.IntegrationAccount -ErrorAc
 InModuleScope Arcus.Scripting.IntegrationAccount {
     Describe "Arcus Azure Integration Account integration tests" {
         BeforeEach {
-            $filePath = "$PSScriptRoot\appsettings.local.json"
+            $filePath = "$PSScriptRoot\appsettings.json"
             [string]$appsettings = Get-Content $filePath
             $config = ConvertFrom-Json $appsettings
             

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.IntegrationAccount.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.IntegrationAccount.tests.ps1
@@ -3,7 +3,7 @@ Import-Module -Name $PSScriptRoot\..\Arcus.Scripting.IntegrationAccount -ErrorAc
 InModuleScope Arcus.Scripting.IntegrationAccount {
     Describe "Arcus Azure Integration Account integration tests" {
         BeforeEach {
-            $filePath = "$PSScriptRoot\appsettings.json"
+            $filePath = "$PSScriptRoot\appsettings.local.json"
             [string]$appsettings = Get-Content $filePath
             $config = ConvertFrom-Json $appsettings
             
@@ -704,7 +704,7 @@ InModuleScope Arcus.Scripting.IntegrationAccount {
                 $expectedCertificateName = $certificate.BaseName
                 $executionDateTime = (Get-Date).ToUniversalTime()
                 $subscriptionId = $config.Arcus.SubscriptionId
-                $keyName = "PrivateCertificateKey"
+                $keyName = "PrivateCertificateKey-$([System.Guid]::NewGuid())"
                 $keyVaultName = $config.Arcus.KeyVault.VaultName
                 $keyVaultId = "/subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.KeyVault/vaults/$keyVaultName"
 


### PR DESCRIPTION
Fixes the conflicted Azure Integration Account private certificate key name in the integration test.

Relates to #276