### PR TITLE
test: removal of purging keyvault key

### DIFF
--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.IntegrationAccount.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.IntegrationAccount.tests.ps1
@@ -723,7 +723,7 @@ InModuleScope Arcus.Scripting.IntegrationAccount {
                 } finally {
                     Remove-AzIntegrationAccountCertificate -ResourceGroupName $resourceGroupName -IntegrationAccountName $integrationAccountName -CertificateName $expectedCertificateName -Force
                     Remove-AzKeyVaultKey -VaultName $config.Arcus.KeyVault.VaultName -Name $keyName -Force
-                    Start-Sleep -Seconds 5
+                    Start-Sleep -Seconds 30
                     Remove-AzKeyVaultKey -VaultName $config.Arcus.KeyVault.VaultName -Name $keyName -Force -InRemovedState
                 }
             }
@@ -756,7 +756,7 @@ InModuleScope Arcus.Scripting.IntegrationAccount {
                 } finally {
                     Remove-AzIntegrationAccountCertificate -ResourceGroupName $resourceGroupName -IntegrationAccountName $integrationAccountName -CertificateName $expectedCertificateName -Force
                     Remove-AzKeyVaultKey -VaultName $config.Arcus.KeyVault.VaultName -Name $keyName -Force
-                    Start-Sleep -Seconds 5
+                    Start-Sleep -Seconds 30
                     Remove-AzKeyVaultKey -VaultName $config.Arcus.KeyVault.VaultName -Name $keyName -Force -InRemovedState
                 }
             }

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.IntegrationAccount.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.IntegrationAccount.tests.ps1
@@ -723,8 +723,6 @@ InModuleScope Arcus.Scripting.IntegrationAccount {
                 } finally {
                     Remove-AzIntegrationAccountCertificate -ResourceGroupName $resourceGroupName -IntegrationAccountName $integrationAccountName -CertificateName $expectedCertificateName -Force
                     Remove-AzKeyVaultKey -VaultName $config.Arcus.KeyVault.VaultName -Name $keyName -Force
-                    Start-Sleep -Seconds 30
-                    Remove-AzKeyVaultKey -VaultName $config.Arcus.KeyVault.VaultName -Name $keyName -Force -InRemovedState
                 }
             }
             It "Create a single private certificate, with prefix, in an Integration Account succeeds" {
@@ -756,8 +754,6 @@ InModuleScope Arcus.Scripting.IntegrationAccount {
                 } finally {
                     Remove-AzIntegrationAccountCertificate -ResourceGroupName $resourceGroupName -IntegrationAccountName $integrationAccountName -CertificateName $expectedCertificateName -Force
                     Remove-AzKeyVaultKey -VaultName $config.Arcus.KeyVault.VaultName -Name $keyName -Force
-                    Start-Sleep -Seconds 30
-                    Remove-AzKeyVaultKey -VaultName $config.Arcus.KeyVault.VaultName -Name $keyName -Force -InRemovedState
                 }
             }
         }


### PR DESCRIPTION
Since we are now using unique keynames we don't need to purge the keyvault keys anymore for the private keys in the private key tests. This was causing tests to sometimes fail as the purging happened to fast after initial deletion.