### PR TITLE
docs: updated Azure DevOps feature docs for setting ARM outputs

### DIFF
--- a/docs/preview/02-Features/powershell/azure-devops.md
+++ b/docs/preview/02-Features/powershell/azure-devops.md
@@ -83,8 +83,9 @@ PS> Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName "my-variable-group"
 # The pipeline variable $variableName will be updated to value $variableValue as well, so it can be used in subsequent tasks of the current job. 
 ```
 
+**Azure DevOps Example**
 This function is intended to be used from an Azure DevOps pipeline. Internally, it uses some predefined Azure DevOps variables.
-One of the environment variables that is used, is the the `SYSTEM_ACCESSTOKEN` variable. However, due to safety reasons this variable is not available out-of-the box.
+One of the environment variables that is used, is the `SYSTEM_ACCESSTOKEN` variable. However, due to safety reasons this variable is not available out-of-the box.
 To be able to use this variable, it must be explicitly added to the environment-variables.
 
 > Note that when you are using a Linux agent, you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
@@ -138,6 +139,7 @@ PS> Set-AzDevOpsArmOutputsToPipelineVariables -ArmOutputsEnvironmentVariableName
 # ##vso[task.setvariable variable=my-variable]my-value
 ```
 
+**Azure DevOps Example**
 This function is intended to be used from an Azure DevOps pipeline.
 
 > Note that when you are using a Linux agent, you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
@@ -174,8 +176,9 @@ PS> Save-AzDevOpsBuild -ProjectId $(System.TeamProjectId) -BuildId $(Build.Build
 # Information on them can be found here: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
 ```
 
+**Azure DevOps Example**
 This function is intended to be used from an Azure DevOps pipeline. Internally, it uses some predefined Azure DevOps variables.
-One of the environment variables that is used, is the the `SYSTEM_ACCESSTOKEN` variable. However, due to safety reasons this variable is not available out-of-the box.
+One of the environment variables that is used, is the `SYSTEM_ACCESSTOKEN` variable. However, due to safety reasons this variable is not available out-of-the box.
 To be able to use this variable, it must be explicitly added to the environment-variables.
 
 Example of how to use this function in an Azure DevOps pipeline:

--- a/docs/preview/02-Features/powershell/azure-devops.md
+++ b/docs/preview/02-Features/powershell/azure-devops.md
@@ -104,6 +104,11 @@ Example of how to use this function in an Azure DevOps pipeline:
       Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName "my-variable-group"
 ```
 
+In DevOps, below permissions need to be set on your variable group in order to make the 'Promote Azure resource outputs to variable group' task succeed:
+
+- Project Collection Build Service (`your devops org name`) - Administrator
+- `your devops project name` Build Service (`your devops org name`) - Administrator
+
 ## Setting ARM outputs to Azure DevOps pipeline variables
 
 Sets the ARM outputs as variables to an Azure DevOps pipeline during the execution of the pipeline.

--- a/docs/preview/02-Features/powershell/azure-devops.md
+++ b/docs/preview/02-Features/powershell/azure-devops.md
@@ -86,7 +86,8 @@ PS> Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName "my-variable-group"
 This function is intended to be used from an Azure DevOps pipeline. Internally, it uses some predefined Azure DevOps variables.
 One of the environment variables that is used, is the the `SYSTEM_ACCESSTOKEN` variable. However, due to safety reasons this variable is not available out-of-the box.
 To be able to use this variable, it must be explicitly added to the environment-variables.
-> Note that when you are using a Linux agent, you need to pass environment variables as these are not available. To be able to use the ArmOutputs environment variable, it must be explicitly added to the environment-variables.
+
+> Note that when you are using a Linux agent, you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
 
 Example of how to use this function in an Azure DevOps pipeline:
 
@@ -138,7 +139,8 @@ PS> Set-AzDevOpsArmOutputsToPipelineVariables -ArmOutputsEnvironmentVariableName
 ```
 
 This function is intended to be used from an Azure DevOps pipeline.
-> Note that when you are using a Linux agent, you need to pass environment variables as these are not available. To be able to use the ArmOutputs environment variable, it must be explicitly added to the environment-variables.
+
+> Note that when you are using a Linux agent, you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
 
 Example of how to use this function in an Azure DevOps pipeline:
 

--- a/docs/preview/02-Features/powershell/azure-devops.md
+++ b/docs/preview/02-Features/powershell/azure-devops.md
@@ -95,7 +95,7 @@ Example of how to use this function in an Azure DevOps pipeline:
   displayName: 'Promote Azure resource outputs to variable group'
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    ArmOutputs: $(ArmOutputs)
+    ArmOutputs: $(ArmOutputs) # only needs to be set for Linux agents
   inputs:
     targetType: 'inline'
     script: |
@@ -146,7 +146,7 @@ Example of how to use this function in an Azure DevOps pipeline:
 - task: PowerShell@2
   displayName: 'Promote Azure resource outputs to pipeline variables'
   env:
-    ArmOutputs: $(ArmOutputs)
+    ArmOutputs: $(ArmOutputs) # only needs to be set for Linux agents
   inputs:
     targetType: 'inline'
     script: |

--- a/docs/preview/02-Features/powershell/azure-devops.md
+++ b/docs/preview/02-Features/powershell/azure-devops.md
@@ -88,7 +88,7 @@ This function is intended to be used from an Azure DevOps pipeline. Internally, 
 One of the environment variables that is used, is the `SYSTEM_ACCESSTOKEN` variable. However, due to safety reasons this variable is not available out-of-the box.
 To be able to use this variable, it must be explicitly added to the environment-variables.
 
-> Note that when you are using a Linux agent, you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
+> ⚠ When you are using a Linux agent, you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
 
 Example of how to use this function in an Azure DevOps pipeline:
 
@@ -106,10 +106,10 @@ Example of how to use this function in an Azure DevOps pipeline:
       Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName "my-variable-group"
 ```
 
-In DevOps, below permissions need to be set on your variable group in order to make the 'Promote Azure resource outputs to variable group' task succeed:
+In Azure DevOps, below permissions need to be set on your variable group in order to make the 'Promote Azure resource outputs to variable group' task succeed. For more information on service accounts, see [the official Azure DevOps documentation](https://docs.microsoft.com/en-us/azure/devops/organizations/security/permissions?view=azure-devops&tabs=preview-page#service-accounts).
 
-- Project Collection Build Service (`your devops org name`) - Administrator
-- `your devops project name` Build Service (`your devops org name`) - Administrator
+- Project Collection Build Service (`<your devops org name>`) - Administrator
+- `<your devops project name>` Build Service (`<your devops org name>`) - Administrator
 
 ## Setting ARM outputs to Azure DevOps pipeline variables
 
@@ -142,7 +142,7 @@ PS> Set-AzDevOpsArmOutputsToPipelineVariables -ArmOutputsEnvironmentVariableName
 **Azure DevOps Example**
 This function is intended to be used from an Azure DevOps pipeline.
 
-> Note that when you are using a Linux agent, you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
+> ⚠ When you are using a Linux agent, you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
 
 Example of how to use this function in an Azure DevOps pipeline:
 

--- a/docs/preview/02-Features/powershell/azure-devops.md
+++ b/docs/preview/02-Features/powershell/azure-devops.md
@@ -49,6 +49,7 @@ Stores the Azure Resource Management (ARM) outputs in a variable group on Azure 
 | `UpdateVariablesForCurrentJob`      | no        | The switch to also set the variables in the ARM output as pipeline variables in the current running job |
 
 **Example**
+
 Without updating the variables in the current job running the pipeline:
 
 ```powershell
@@ -91,6 +92,7 @@ Sets the ARM outputs as variables to an Azure DevOps pipeline during the executi
 | `ArmOutputsEnvironmentVariableName` | no        | The name of the environment variable where the ARM outputs are located (default: `ArmOutputs`) |
 
 **Example**
+
 With default `ArmOutputs` environment variable containing: `"my-variable": "my-value"`:
 
 ```powershell
@@ -107,6 +109,23 @@ PS> Set-AzDevOpsArmOutputsToPipelineVariables -ArmOutputsEnvironmentVariableName
 # Get ARM outputs from 'MyArmOutputs' environment variable
 # The pipeline variable my-variable will be updated to value my-value, so it can be used in subsequent tasks of the current job. 
 # ##vso[task.setvariable variable=my-variable]my-value
+```
+
+This function is intended to be used from an Azure DevOps pipeline. Note that when you are using a Linux agent, you need to pass environment variables as these are not available out of the box. To be able to use the ArmOutputsEnvironmentVariableName, it must be explicitly added to the environment-variables.
+
+Example of how to use this function in an Azure DevOps pipeline:
+
+```yaml
+- task: PowerShell@2
+  displayName: 'Promote Azure resource outputs to pipeline variables'
+  env:
+    ArmOutputs: $(ArmOutputs)
+  inputs:
+    targetType: 'inline'
+    script: |
+      Install-Module -Name Arcus.Scripting.DevOps -Force
+
+      Set-AzDevOpsArmOutputsToPipelineVariables
 ```
 
 ## Save Azure DevOps build

--- a/docs/preview/02-Features/powershell/azure-devops.md
+++ b/docs/preview/02-Features/powershell/azure-devops.md
@@ -84,9 +84,9 @@ PS> Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName "my-variable-group"
 ```
 
 This function is intended to be used from an Azure DevOps pipeline. Internally, it uses some predefined Azure DevOps variables.
-One of the environment variables that is used, is the the `SYSTEM_ACCESSTOKEN` variable.  However, due to safety reasons this variable is not available out-of-the box.
+One of the environment variables that is used, is the the `SYSTEM_ACCESSTOKEN` variable. However, due to safety reasons this variable is not available out-of-the box.
 To be able to use this variable, it must be explicitly added to the environment-variables.
-Note also that when you are using a Linux agent, you need to pass environment variables as these are not available. To be able to use the ArmOutputs environment variable, it must be explicitly added to the environment-variables.
+> Note that when you are using a Linux agent, you need to pass environment variables as these are not available. To be able to use the ArmOutputs environment variable, it must be explicitly added to the environment-variables.
 
 Example of how to use this function in an Azure DevOps pipeline:
 
@@ -138,7 +138,7 @@ PS> Set-AzDevOpsArmOutputsToPipelineVariables -ArmOutputsEnvironmentVariableName
 ```
 
 This function is intended to be used from an Azure DevOps pipeline.
-Note that when you are using a Linux agent, you need to pass environment variables as these are not available. To be able to use the ArmOutputs environment variable, it must be explicitly added to the environment-variables.
+> Note that when you are using a Linux agent, you need to pass environment variables as these are not available. To be able to use the ArmOutputs environment variable, it must be explicitly added to the environment-variables.
 
 Example of how to use this function in an Azure DevOps pipeline:
 
@@ -173,7 +173,7 @@ PS> Save-AzDevOpsBuild -ProjectId $(System.TeamProjectId) -BuildId $(Build.Build
 ```
 
 This function is intended to be used from an Azure DevOps pipeline. Internally, it uses some predefined Azure DevOps variables.
-One of the environment variables that is used, is the the `SYSTEM_ACCESSTOKEN` variable.  However, due to safety reasons this variable is not available out-of-the box.
+One of the environment variables that is used, is the the `SYSTEM_ACCESSTOKEN` variable. However, due to safety reasons this variable is not available out-of-the box.
 To be able to use this variable, it must be explicitly added to the environment-variables.
 
 Example of how to use this function in an Azure DevOps pipeline:

--- a/docs/preview/02-Features/powershell/azure-devops.md
+++ b/docs/preview/02-Features/powershell/azure-devops.md
@@ -83,6 +83,27 @@ PS> Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName "my-variable-group"
 # The pipeline variable $variableName will be updated to value $variableValue as well, so it can be used in subsequent tasks of the current job. 
 ```
 
+This function is intended to be used from an Azure DevOps pipeline. Internally, it uses some predefined Azure DevOps variables.
+One of the environment variables that is used, is the the `SYSTEM_ACCESSTOKEN` variable.  However, due to safety reasons this variable is not available out-of-the box.
+To be able to use this variable, it must be explicitly added to the environment-variables.
+Note also that when you are using a Linux agent, you need to pass environment variables as these are not available. To be able to use the ArmOutputs environment variable, it must be explicitly added to the environment-variables.
+
+Example of how to use this function in an Azure DevOps pipeline:
+
+```yaml
+- task: PowerShell@2
+  displayName: 'Promote Azure resource outputs to variable group'
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    ArmOutputs: $(ArmOutputs)
+  inputs:
+    targetType: 'inline'
+    script: |
+      Install-Module -Name Arcus.Scripting.DevOps -Force
+
+      Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName "my-variable-group"
+```
+
 ## Setting ARM outputs to Azure DevOps pipeline variables
 
 Sets the ARM outputs as variables to an Azure DevOps pipeline during the execution of the pipeline.
@@ -111,7 +132,8 @@ PS> Set-AzDevOpsArmOutputsToPipelineVariables -ArmOutputsEnvironmentVariableName
 # ##vso[task.setvariable variable=my-variable]my-value
 ```
 
-This function is intended to be used from an Azure DevOps pipeline. Note that when you are using a Linux agent, you need to pass environment variables as these are not available out of the box. To be able to use the ArmOutputsEnvironmentVariableName, it must be explicitly added to the environment-variables.
+This function is intended to be used from an Azure DevOps pipeline.
+Note that when you are using a Linux agent, you need to pass environment variables as these are not available. To be able to use the ArmOutputs environment variable, it must be explicitly added to the environment-variables.
 
 Example of how to use this function in an Azure DevOps pipeline:
 
@@ -145,7 +167,7 @@ PS> Save-AzDevOpsBuild -ProjectId $(System.TeamProjectId) -BuildId $(Build.Build
 # Information on them can be found here: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
 ```
 
-This function is intended to be used from an Azure DevOps pipeline.  Internally, it uses some predefined Azure DevOps variables.
+This function is intended to be used from an Azure DevOps pipeline. Internally, it uses some predefined Azure DevOps variables.
 One of the environment variables that is used, is the the `SYSTEM_ACCESSTOKEN` variable.  However, due to safety reasons this variable is not available out-of-the box.
 To be able to use this variable, it must be explicitly added to the environment-variables.
 


### PR DESCRIPTION
Added YAML examples for Set-AzDevOpsArmOutputsToPipelineVariables and Set-AzDevOpsArmOutputsToVariableGroup using Windows and Linux agents. Also documented required variable group permissions for Set-AzDevOpsArmOutputsToVariableGroup.

Closes #212 