### PR TITLE
feat: Add logging to Get-AzKeyVaultAccessPolicies #271

### DIFF
--- a/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
+++ b/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
@@ -32,9 +32,14 @@ if($keyVault) {
              storage = $keyVaultAccessPolicy.PermissionsToStorage
           }
 
+          Write-Verbose "Access Policy successfully retrieved for TenantId: $($armAccessPolicy.tenantId) and ObjectId: $($armAccessPolicy.ObjectId)"
+          Write-Verbose ($armAccessPolicyPermissions | Format-list | Out-String) 
+
           $armAccessPolicy | Add-Member -MemberType NoteProperty -Name permissions -Value $armAccessPolicyPermissions
           $armAccessPolicies += $armAccessPolicy
-       }   
+       }       
+       
+        Write-Host "Successfully retrieved Access Policies"
     }    
 } else {
     Write-Warning "Azure Key Vault '$keyVaultName' could not be found, please check if the provided vault name and/or resource group name is correct."

--- a/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
+++ b/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
@@ -44,5 +44,4 @@ $armAccessPoliciesParameter = [pscustomobject]@{
     list = $armAccessPolicies
 }
 
-Write-Host "Current access policies: $armAccessPoliciesParameter"
 return $armAccessPoliciesParameter

--- a/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
+++ b/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
@@ -39,7 +39,7 @@ if($keyVault) {
           $armAccessPolicies += $armAccessPolicy
        }       
        
-        Write-Host "Successfully retrieved Access Policies"
+        Write-Host "Successfully retrieved Azure Key Vault access policies"
     }    
 } else {
     Write-Warning "Azure Key Vault '$keyVaultName' could not be found, please check if the provided vault name and/or resource group name is correct."

--- a/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
+++ b/src/Arcus.Scripting.KeyVault/Scripts/Get-AzKeyVaultAccessPolicies.ps1
@@ -32,7 +32,7 @@ if($keyVault) {
              storage = $keyVaultAccessPolicy.PermissionsToStorage
           }
 
-          Write-Verbose "Access Policy successfully retrieved for TenantId: $($armAccessPolicy.tenantId) and ObjectId: $($armAccessPolicy.ObjectId)"
+          Write-Verbose "Azure Key Vault access policy successfully retrieved for TenantId: $($armAccessPolicy.tenantId) and ObjectId: $($armAccessPolicy.ObjectId)"
           Write-Verbose ($armAccessPolicyPermissions | Format-list | Out-String) 
 
           $armAccessPolicy | Add-Member -MemberType NoteProperty -Name permissions -Value $armAccessPolicyPermissions

--- a/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.KeyVault.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.KeyVault.tests.ps1
@@ -22,7 +22,7 @@ InModuleScope Arcus.Scripting.KeyVault {
                 Mock Get-AzKeyVault { return [pscustomobject]@{ accessPolicies = @($accessPolicy) }  }
                 
                 # Act
-                $accessPoliciesParameter = Get-AzKeyVaultAccessPolicies -KeyVaultName "key vault" -ResourceGroupName "resource group name"
+                $accessPoliciesParameter = Get-AzKeyVaultAccessPolicies -KeyVaultName "key vault" -ResourceGroupName "resource group name" -verbose
                 
                 # Assert
                 $accessPolicies = $accessPoliciesParameter.list


### PR DESCRIPTION
Write-Host when all the policies are successfully retrieving from key vault and also added details in verbose for each policy. 
The following fields are printed in verbose logging: Tenant Id; Object Id;  Keys; Secrets; Certificates; Storage
Closes #271 

Note: The fields Keys, Secrets, Certificates and Storage only display information about the access permissions of the policy, not the sensitive data. 
E.g. keys : {Get, List, Set, Delete}