### PR TITLE
docs: updated Azure DevOps feature docs regarding installing Arcus packages in pipelines

### DIFF
--- a/docs/preview/02-Features/powershell/azure-devops.md
+++ b/docs/preview/02-Features/powershell/azure-devops.md
@@ -88,7 +88,7 @@ This function is intended to be used from an Azure DevOps pipeline. Internally, 
 One of the environment variables that is used, is the `SYSTEM_ACCESSTOKEN` variable. However, due to safety reasons this variable is not available out-of-the box.
 To be able to use this variable, it must be explicitly added to the environment-variables.
 
-> ⚠ When you are using a Linux agent, you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
+> ⚠ When you are using a Linux agent (which is recommended), you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
 
 Example of how to use this function in an Azure DevOps pipeline:
 
@@ -143,7 +143,7 @@ PS> Set-AzDevOpsArmOutputsToPipelineVariables -ArmOutputsEnvironmentVariableName
 **Azure DevOps Example**
 This function is intended to be used from an Azure DevOps pipeline.
 
-> ⚠ When you are using a Linux agent, you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
+> ⚠ When you are using a Linux agent (which is recommended), you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
 
 Example of how to use this function in an Azure DevOps pipeline:
 

--- a/docs/preview/02-Features/powershell/azure-devops.md
+++ b/docs/preview/02-Features/powershell/azure-devops.md
@@ -88,7 +88,9 @@ This function is intended to be used from an Azure DevOps pipeline. Internally, 
 One of the environment variables that is used, is the `SYSTEM_ACCESSTOKEN` variable. However, due to safety reasons this variable is not available out-of-the box.
 To be able to use this variable, it must be explicitly added to the environment-variables.
 
-> ⚠ When you are using a Linux agent (which is recommended), you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
+> ⚠ When you are using a Linux agent, you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
+
+> We have seen a much better performance when using Linux agents, and would recommend using Linux agents when possible.
 
 Example of how to use this function in an Azure DevOps pipeline:
 
@@ -143,7 +145,9 @@ PS> Set-AzDevOpsArmOutputsToPipelineVariables -ArmOutputsEnvironmentVariableName
 **Azure DevOps Example**
 This function is intended to be used from an Azure DevOps pipeline.
 
-> ⚠ When you are using a Linux agent (which is recommended), you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
+> ⚠ When you are using a Linux agent, you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
+
+> We have seen a much better performance when using Linux agents, and would recommend using Linux agents when possible.
 
 Example of how to use this function in an Azure DevOps pipeline:
 

--- a/docs/preview/02-Features/powershell/azure-devops.md
+++ b/docs/preview/02-Features/powershell/azure-devops.md
@@ -101,7 +101,8 @@ Example of how to use this function in an Azure DevOps pipeline:
   inputs:
     targetType: 'inline'
     script: |
-      Install-Module -Name Arcus.Scripting.DevOps -Force
+      Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+      Install-Module -Name Arcus.Scripting.DevOps -Repository PSGallery -AllowClobber
 
       Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName "my-variable-group"
 ```
@@ -154,7 +155,8 @@ Example of how to use this function in an Azure DevOps pipeline:
   inputs:
     targetType: 'inline'
     script: |
-      Install-Module -Name Arcus.Scripting.DevOps -Force
+      Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+      Install-Module -Name Arcus.Scripting.DevOps -Repository PSGallery -AllowClobber
 
       Set-AzDevOpsArmOutputsToPipelineVariables
 ```
@@ -192,7 +194,8 @@ Example of how to use this function in an Azure DevOps pipeline:
     targetType: 'inline'
     pwsh: true
     script: |
-      Install-Module -Name Arcus.Scripting.DevOps -Force
+      Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+      Install-Module -Name Arcus.Scripting.DevOps -Repository PSGallery -AllowClobber
 
       $project = "$(System.TeamProjectId)"
       $buildId = $(Build.BuildId)

--- a/docs/preview/02-Features/powershell/azure-devops.md
+++ b/docs/preview/02-Features/powershell/azure-devops.md
@@ -90,7 +90,7 @@ To be able to use this variable, it must be explicitly added to the environment-
 
 > ⚠ When you are using a Linux agent, you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
 
-> We have seen a much better performance when using Linux agents, and would recommend using Linux agents when possible.
+> 💡 We have seen a much better performance when using Linux agents, and would recommend using Linux agents when possible.
 
 Example of how to use this function in an Azure DevOps pipeline:
 
@@ -147,7 +147,7 @@ This function is intended to be used from an Azure DevOps pipeline.
 
 > ⚠ When you are using a Linux agent, you need to pass other environment variables that you want to use as well, because these are not available. To be able to use the `ArmOutputs` environment variable, it must be explicitly added to the environment-variables.
 
-> We have seen a much better performance when using Linux agents, and would recommend using Linux agents when possible.
+> 💡 We have seen a much better performance when using Linux agents, and would recommend using Linux agents when possible.
 
 Example of how to use this function in an Azure DevOps pipeline:
 

--- a/docs/preview/02-Features/powershell/azure-devops.md
+++ b/docs/preview/02-Features/powershell/azure-devops.md
@@ -19,7 +19,8 @@ This module provides the following capabilities:
 To have access to the following features, you have to import the module:
 
 ```powershell
-PS> Install-Module -Name Arcus.Scripting.DevOps
+PS> Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+PS> Install-Module -Name Arcus.Scripting.DevOps -Repository PSGallery -AllowClobber
 ```
 
 ## Setting a variable in an Azure DevOps pipeline


### PR DESCRIPTION
Updated the Azure DevOps docs on how to install the Arcus packages inside your pipeline.
Previously, using -Force, this step could take up to 5 minutes.
Now, by registering the repository and using -AllowClobber step takes one minute.

Relates to #284 