### PR TITLE
docs: fix az management title in feature docs

### DIFF
--- a/docs/preview/02-Features/powershell/azure-app-service.md
+++ b/docs/preview/02-Features/powershell/azure-app-service.md
@@ -24,7 +24,7 @@ Create/update a single application setting within an Azure App Service.
 
 | Parameter                     | Mandatory   | Description                                                                                           |
 | ----------------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
-| `ResourceGroupName`           | yes         | The name of the Azure resource group where the Azure Integration Account is located.                  |
+| `ResourceGroupName`           | yes         | The name of the Azure resource group where the Azure App Service is located.                          |
 | `AppServiceName`              | yes         | The name of the Azure App Service where the application setting will be created/updated.              |
 | `AppServiceSettingName`       | yes         | The name of the application setting that will be created/updated.                                     |
 | `AppServiceSettingValue`      | yes         | The value of the application setting that will be created/updated.                                    |

--- a/docs/preview/02-Features/powershell/azure-management.md
+++ b/docs/preview/02-Features/powershell/azure-management.md
@@ -1,4 +1,3 @@
-
 ---
 title: "Azure Management"
 layout: default

--- a/docs/versioned_docs/version-v0.6.0/02-Features/powershell/azure-app-service.md
+++ b/docs/versioned_docs/version-v0.6.0/02-Features/powershell/azure-app-service.md
@@ -24,7 +24,7 @@ Create/update a single application setting within an Azure App Service.
 
 | Parameter                     | Mandatory   | Description                                                                                           |
 | ----------------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
-| `ResourceGroupName`           | yes         | The name of the Azure resource group where the Azure Integration Account is located.                  |
+| `ResourceGroupName`           | yes         | The name of the Azure resource group where the Azure App Service is located.                          |
 | `AppServiceName`              | yes         | The name of the Azure App Service where the application setting will be created/updated.              |
 | `AppServiceSettingName`       | yes         | The name of the application setting that will be created/updated.                                     |
 | `AppServiceSettingValue`      | yes         | The value of the application setting that will be created/updated.                                    |

--- a/docs/versioned_docs/version-v0.6.0/02-Features/powershell/azure-management.md
+++ b/docs/versioned_docs/version-v0.6.0/02-Features/powershell/azure-management.md
@@ -1,4 +1,3 @@
-
 ---
 title: "Azure Management"
 layout: default


### PR DESCRIPTION
Due to the fact that the layout code was not on the first line, we had some problems with formatting. Should be fixed now.