### PR TITLE
fix: fixed casing of parameter and fixed return param of Set-AzApiManagementPolicy command

### DIFF
--- a/src/Arcus.Scripting.ApiManagement/Scripts/Import-AzApiManagementApiPolicy.ps1
+++ b/src/Arcus.Scripting.ApiManagement/Scripts/Import-AzApiManagementApiPolicy.ps1
@@ -2,7 +2,7 @@ param(
    [Parameter(Mandatory = $true)][string] $ResourceGroupName,
    [Parameter(Mandatory = $true)][string] $ServiceName,
    [Parameter(Mandatory = $true)][string] $ApiId,
-   [Parameter(Mandatory = $true)][string] $policyFilePath
+   [Parameter(Mandatory = $true)][string] $PolicyFilePath
 )
 
 $apim = Get-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName
@@ -12,7 +12,7 @@ if ($apim -eq $null) {
 $apimContext = New-AzApiManagementContext -ResourceGroupName $ResourceGroupName -ServiceName $ServiceName
 
 Write-Host "Updating policy of API '$ApiId'"
-$result = Set-AzApiManagementPolicy -Context $apimContext -ApiId $ApiId -PolicyFilePath $policyFilePath
+$result = Set-AzApiManagementPolicy -Context $apimContext -ApiId $ApiId -PolicyFilePath $PolicyFilePath
 if ($result) {
     Write-Host "Successfully updated API policy"
 } else {

--- a/src/Arcus.Scripting.ApiManagement/Scripts/Import-AzApiManagementApiPolicy.ps1
+++ b/src/Arcus.Scripting.ApiManagement/Scripts/Import-AzApiManagementApiPolicy.ps1
@@ -12,7 +12,7 @@ if ($apim -eq $null) {
 $apimContext = New-AzApiManagementContext -ResourceGroupName $ResourceGroupName -ServiceName $ServiceName
 
 Write-Host "Updating policy of API '$ApiId'"
-$result = Set-AzApiManagementPolicy -Context $apimContext -ApiId $ApiId -PolicyFilePath $PolicyFilePath
+$result = Set-AzApiManagementPolicy -Context $apimContext -ApiId $ApiId -PolicyFilePath $PolicyFilePath -PassThru
 if ($result) {
     Write-Host "Successfully updated API policy"
 } else {

--- a/src/Arcus.Scripting.ApiManagement/Scripts/Import-AzApiManagementOperationPolicy.ps1
+++ b/src/Arcus.Scripting.ApiManagement/Scripts/Import-AzApiManagementOperationPolicy.ps1
@@ -13,7 +13,7 @@ if ($apim -eq $null) {
 $apimContext = New-AzApiManagementContext -ResourceGroupName $ResourceGroupName -ServiceName $ServiceName
 
 Write-Host "Updating policy of the operation '$OperationId' in API '$ApiId'"
-$result = Set-AzApiManagementPolicy -Context $apimContext -ApiId $ApiId -OperationId $OperationId -PolicyFilePath $PolicyFilePath
+$result = Set-AzApiManagementPolicy -Context $apimContext -ApiId $ApiId -OperationId $OperationId -PolicyFilePath $PolicyFilePath -PassThru
 if ($result) {
     Write-Host "Successfully updated the operation policy"
 } else {

--- a/src/Arcus.Scripting.ApiManagement/Scripts/Import-AzApiManagementProductPolicy.ps1
+++ b/src/Arcus.Scripting.ApiManagement/Scripts/Import-AzApiManagementProductPolicy.ps1
@@ -12,7 +12,7 @@ if ($apim -eq $null) {
 $apimContext = New-AzApiManagementContext -ResourceGroupName $ResourceGroupName -ServiceName $ServiceName
 
 Write-Host "Updating policy of product '$ProductId'"
-$result = Set-AzApiManagementPolicy -Context $apimContext -ProductId $ProductId -PolicyFilePath $PolicyFilePath
+$result = Set-AzApiManagementPolicy -Context $apimContext -ProductId $ProductId -PolicyFilePath $PolicyFilePath -PassThru
 if ($result) {
     Write-Host "Successfully updated the product policy"
 } else {


### PR DESCRIPTION
- Fixed the casing of `PolicyFilePath` parameter in the `Import-AzApiManagementApiPolicy` command.
- Added the `-PassThru` param to the `Set-AzApiManagementPolicy` to fix the `Import-AzApiManagementApiPolicy`, `Import-AzApiManagementOperationPolicy` and `Import-AzApiManagementProductPolicy` commands

Closes https://github.com/arcus-azure/arcus.scripting/issues/322
Closes https://github.com/arcus-azure/arcus.scripting/issues/323