### PR TITLE
test: assert trimmed day in integration account tests

### DIFF
--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.IntegrationAccount.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.IntegrationAccount.tests.ps1
@@ -715,7 +715,7 @@ InModuleScope Arcus.Scripting.IntegrationAccount {
                     # Assert
                     $actual = Get-AzIntegrationAccountCertificate -ResourceGroupName $resourceGroupName -IntegrationAccountName $integrationAccountName -CertificateName $expectedCertificateName
                     $actual | Should -Not -BeNullOrEmpty 
-                    $actual.CreatedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss") | Should -BeIn @($actual.ChangedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss"), $actual.ChangedTime.ToUniversalTime().AddSeconds(-1).ToString("yyyy-MM-ddTHH:mm:ss"))
+                    $actual.CreatedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH") | Should -Be $actual.ChangedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH")
                     $actual.CreatedTime | Should -BeGreaterOrEqual $executionDateTime
 
                 } finally {
@@ -746,7 +746,7 @@ InModuleScope Arcus.Scripting.IntegrationAccount {
                     # Assert
                     $actual = Get-AzIntegrationAccountCertificate -ResourceGroupName $resourceGroupName -IntegrationAccountName $integrationAccountName -CertificateName $expectedCertificateName
                     $actual | Should -Not -BeNullOrEmpty 
-                    $actual.CreatedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss") | Should -BeIn @($actual.ChangedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss"), $actual.ChangedTime.ToUniversalTime().AddSeconds(-1).ToString("yyyy-MM-ddTHH:mm:ss"))
+                    $actual.CreatedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH") | Should -Be $actual.ChangedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH")
                     $actual.CreatedTime | Should -BeGreaterOrEqual $executionDateTime
 
                 } finally {
@@ -783,7 +783,7 @@ InModuleScope Arcus.Scripting.IntegrationAccount {
                     # Assert
                     $actual = Get-AzIntegrationAccountPartner -ResourceGroupName $resourceGroupName -IntegrationAccountName $integrationAccountName -PartnerName $expectedPartnerName
                     $actual | Should -Not -BeNullOrEmpty 
-                    $actual.CreatedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss") | Should -BeIn @($actual.ChangedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss"), $actual.ChangedTime.ToUniversalTime().AddSeconds(-1).ToString("yyyy-MM-ddTHH:mm:ss"))
+                    $actual.CreatedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH") | Should -Be $actual.ChangedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH")
                     $actual.CreatedTime | Should -BeGreaterOrEqual $executionDateTime
 
                 } finally {
@@ -808,7 +808,7 @@ InModuleScope Arcus.Scripting.IntegrationAccount {
                     # Assert
                     $actual = Get-AzIntegrationAccountPartner -ResourceGroupName $resourceGroupName -IntegrationAccountName $integrationAccountName -PartnerName $expectedPartnerName
                     $actual | Should -Not -BeNullOrEmpty
-                    $actual.CreatedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss") | Should -BeIn ($existingPartner.ChangedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss"), $existingPartner.ChangedTime.ToUniversalTime().AddSeconds(-1).ToString("yyyy-MM-ddTHH:mm:ss"))
+                    $actual.CreatedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH") | Should -Be $existingPartner.ChangedTime.ToUniversalTime().ToString("yyyy-MM-ddTHH")
                     $actual.ChangedTime.ToUniversalTime() | Should -BeGreaterOrEqual $executionDateTime
                     $existingPartner.CreatedTime.ToUniversalTime() | Should -BeLessOrEqual $actual.ChangedTime.ToUniversalTime()
 


### PR DESCRIPTION
Since the integration tests were asserting on seconds, we would sometimes get failues in the like of `Expected collection @('2022-12-23T05:33:25', '2022-12-23T05:33:24') to contain '2022-12-23T05:26:03', but it was not found.` because there is a time delay somewhere that causes the expected creation time of Azure Integration account types to shift. Therefore, it would be better to assert the creation time trimmed on the day instead of on the second. Then, only when you work arround midnight and run the tests at an exact time, you would maybe run into this 😀.