### PR TITLE
chore: use `main` branch in az devops status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Arcus Scripting
-[![Build Status](https://dev.azure.com/codit/Arcus/_apis/build/status/Commit%20builds/CI%20-%20Arcus.Scripting?branchName=master)](https://dev.azure.com/codit/Arcus/_build/latest?definitionId=843&branchName=master)
+[![Build Status](https://dev.azure.com/codit/Arcus/_apis/build/status/Commit%20builds/CI%20-%20Arcus.Scripting?branchName=main)](https://dev.azure.com/codit/Arcus/_build/latest?definitionId=843&branchName=main)
 [![PowerShell Gallery Version](https://img.shields.io/powershellgallery/v/Arcus.Scripting.ARM)](https://www.powershellgallery.com/packages/Arcus.Scripting.ARM/)
 
 Scripting with Microsoft Azure in a breeze.


### PR DESCRIPTION
Use default `main` branch in Azure DevOps status badge.