### PR TITLE
fix: use latest version of nuget during release

### DIFF
--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -148,6 +148,7 @@ stages:
               packDestination: '$(Build.ArtifactStagingDirectory)'
           - task: NuGetToolInstaller@1
             displayName: 'Install NuGet'
+            checkLatest: true
           - powershell: |
               Get-ChildItem -Path $env:ARTIFACT_DIR -Filter *.nupkg -Recurse |
                 % { & "nuget" push $_.FullName -Source $(Source) -ApiKey $(NuGet.ApiKey) -SkipDuplicate | Out-File log.txt -Append }


### PR DESCRIPTION
The release to the powershell gallery sometimes failes because of the version of the nuget tool. This PR makes sure we always use the latest version of the tool.