### PR TITLE
fix: Redundant use of Get-AzLogicAppRunHistory

### DIFF
--- a/src/Arcus.Scripting.LogicApps/Scripts/Disable-AzLogicAppsFromConfig.ps1
+++ b/src/Arcus.Scripting.LogicApps/Scripts/Disable-AzLogicAppsFromConfig.ps1
@@ -65,7 +65,8 @@ function ExecuteCheckType() {
                                 Write-Verbose "Azure Logic App '$logicApp' has Running and/or Waiting Runs, waiting 10 seconds and checking again..."
                                 Write-Debug "Number of running runs: $RunningRunsCount"
                                 Write-Debug "Number of waiting runs: $WaitingRunsCount"
-                                Start-Sleep -Second 10                               
+                                Start-Sleep -Second 10
+                                $runHistory = Get-AzLogicAppRunHistory -ResourceGroupName $ResourceGroupName -Name $logicApp -FollowNextPageLink -ErrorAction Stop
                                 $RunningRunsCount = ($runHistory | Where-Object { $_.Status -eq "Running" }).Count
                                 $WaitingRunsCount = ($runHistory | Where-Object { $_.Status -eq "Waiting" }).Count
                                 if ($RunningRunsCount -eq 0 -and $WaitingRunsCount -eq 0) {

--- a/src/Arcus.Scripting.LogicApps/Scripts/Disable-AzLogicAppsFromConfig.ps1
+++ b/src/Arcus.Scripting.LogicApps/Scripts/Disable-AzLogicAppsFromConfig.ps1
@@ -67,9 +67,10 @@ function ExecuteCheckType() {
                                 Write-Debug "Number of waiting runs: $WaitingRunsCount"
                                 Start-Sleep -Second 10                               
                                 $RunningRunsCount = ($runHistory | Where-Object { $_.Status -eq "Running" }).Count
-                                $WaitingRunsCount = ($runHistory | Where-Object { $_.Status -eq "Waiting" }).Countif ($RunningRunsCount -eq 0 -and $WaitingRunsCount -eq 0) {
-                                Write-Verbose "Found no more waiting or running runs for Azure Logic App '$logicApp', executing stopType for Logic App"
-                                ExecuteStopType -resourceGroupName $ResourceGroupName -LogicAppName $logicApp -stopType $batch.stopType
+                                $WaitingRunsCount = ($runHistory | Where-Object { $_.Status -eq "Waiting" }).Count
+                                if ($RunningRunsCount -eq 0 -and $WaitingRunsCount -eq 0) {
+                                    Write-Verbose "Found no more waiting or running runs for Azure Logic App '$logicApp', executing stopType for Logic App"
+                                    ExecuteStopType -resourceGroupName $ResourceGroupName -LogicAppName $logicApp -stopType $batch.stopType
                                 }
                             }
                         } else{

--- a/src/Arcus.Scripting.LogicApps/Scripts/Disable-AzLogicAppsFromConfig.ps1
+++ b/src/Arcus.Scripting.LogicApps/Scripts/Disable-AzLogicAppsFromConfig.ps1
@@ -57,19 +57,19 @@ function ExecuteCheckType() {
                     }
 
                     try {
-                        $RunningRunsCount = Get-AzLogicAppRunHistory -ResourceGroupName $ResourceGroupName -Name $logicApp -FollowNextPageLink -ErrorAction Stop | Where-Object Status -eq "Running" | Measure-Object | ForEach-Object { $_.Count }
-                        $WaitingRunsCount = Get-AzLogicAppRunHistory -ResourceGroupName $ResourceGroupName -Name $logicApp -FollowNextPageLink -ErrorAction Stop | Where-Object Status -eq "Waiting" | Measure-Object | ForEach-Object { $_.Count }
+                        $runHistory = Get-AzLogicAppRunHistory -ResourceGroupName $ResourceGroupName -Name $logicApp -FollowNextPageLink -ErrorAction Stop
+                        $RunningRunsCount = ($runHistory | Where-Object { $_.Status -eq "Running" }).Count
+                        $WaitingRunsCount = ($runHistory | Where-Object { $_.Status -eq "Waiting" }).Count
                         if ($RunningRunsCount -ne 0 -and $WaitingRunsCount -ne 0) {
                             while ($RunningRunsCount -ne 0 -and $WaitingRunsCount -ne 0) {
                                 Write-Verbose "Azure Logic App '$logicApp' has Running and/or Waiting Runs, waiting 10 seconds and checking again..."
                                 Write-Debug "Number of running runs: $RunningRunsCount"
                                 Write-Debug "Number of waiting runs: $WaitingRunsCount"
                                 Start-Sleep -Second 10                               
-                                $RunningRunsCount = Get-AzLogicAppRunHistory -ResourceGroupName $ResourceGroupName -Name $logicApp -FollowNextPageLink -ErrorAction Stop | Where-Object Status -eq "Running" | Measure-Object | ForEach-Object { $_.Count }
-                                $WaitingRunsCount = Get-AzLogicAppRunHistory -ResourceGroupName $ResourceGroupName -Name $logicApp -FollowNextPageLink -ErrorAction Stop | Where-Object Status -eq "Waiting" | Measure-Object | ForEach-Object { $_.Count }
-                                if ($RunningRunsCount -eq 0 -and $WaitingRunsCount -eq 0) {
-                                    Write-Verbose "Found no more waiting or running runs for Azure Logic App '$logicApp', executing stopType for Logic App"
-                                    ExecuteStopType -resourceGroupName $ResourceGroupName -LogicAppName $logicApp -stopType $batch.stopType
+                                $RunningRunsCount = ($runHistory | Where-Object { $_.Status -eq "Running" }).Count
+                                $WaitingRunsCount = ($runHistory | Where-Object { $_.Status -eq "Waiting" }).Countif ($RunningRunsCount -eq 0 -and $WaitingRunsCount -eq 0) {
+                                Write-Verbose "Found no more waiting or running runs for Azure Logic App '$logicApp', executing stopType for Logic App"
+                                ExecuteStopType -resourceGroupName $ResourceGroupName -LogicAppName $logicApp -stopType $batch.stopType
                                 }
                             }
                         } else{

--- a/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.LogicApps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.LogicApps.tests.ps1
@@ -191,7 +191,7 @@ InModuleScope Arcus.Scripting.LogicApps {
 
                 # Assert
                 Assert-MockCalled Get-AzCachedAccessToken -Scope It -Times 1
-                Assert-MockCalled Get-AzLogicAppRunHistory -Scope It -Times 6 -ParameterFilter { $ResourceGroupName -eq $resourceGroup }
+                Assert-MockCalled Get-AzLogicAppRunHistory -Scope It -Times 3 -ParameterFilter { $ResourceGroupName -eq $resourceGroup }
                 Assert-MockCalled Disable-AzLogicApp -Scope It -Exactly 0
             }
             It "Doesn't disable anything when checkType = NoWaitingOrRunningRuns but returns a zero count on an the waiting runs for stopType = None" {
@@ -216,10 +216,10 @@ InModuleScope Arcus.Scripting.LogicApps {
 
                 # Assert
                 Assert-MockCalled Get-AzCachedAccessToken -Scope It -Times 1
-                Assert-MockCalled Get-AzLogicAppRunHistory -Times 4 -ParameterFilter { $ResourceGroupName -eq $resourceGroup }
+                Assert-MockCalled Get-AzLogicAppRunHistory -Times 2 -ParameterFilter { $ResourceGroupName -eq $resourceGroup }
                 Assert-MockCalled Disable-AzLogicApp -Scope It -Exactly 0
             }
-            It "Disbales all logic apps when checkType = NoWaitingOrRunningRuns with found waiting and no running runs for stopType = Immediate" {
+            It "Disables all logic apps when checkType = NoWaitingOrRunningRuns with found waiting and no running runs for stopType = Immediate" {
                 # Arrange
                 $resourceGroup = "my-resource-group"
                 $logicAppNames = @("snd-async", "ord-sthp-harvest-order-doublechecker", "rcv-sthp-harvest-order-af-ftp", "rcv-sthp-harvest-order-af-sft", "rcv-sthp-harvest-order-af-file")
@@ -244,7 +244,7 @@ InModuleScope Arcus.Scripting.LogicApps {
 
                 # Assert
                 Assert-MockCalled Get-AzCachedAccessToken -Scope It -Times 1
-                Assert-MockCalled Get-AzLogicAppRunHistory -Scope It -Times 10 -ParameterFilter { $ResourceGroupName -eq $resourceGroup }
+                Assert-MockCalled Get-AzLogicAppRunHistory -Scope It -Times 5 -ParameterFilter { $ResourceGroupName -eq $resourceGroup }
                 Assert-MockCalled Disable-AzLogicApp -Scope It -Exactly 5 -ParameterFilter { $resourceGroupName -eq $resourceGroup }
             }
             It "Disables all logic apps when checkType = NoWaitingOrRunningRuns with found waiting and running runs for stopType = Immediate" {


### PR DESCRIPTION
Get-AzLogicAppRunHistory is used multiple times when it only needs to be used once, optimisation