### PR TITLE
fix: Make sure the log.txt file exists during release pipeline

### DIFF
--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -151,6 +151,7 @@ stages:
             inputs:
               checkLatest: true
           - powershell: |
+              New-Item log.txt
               Get-ChildItem -Path $env:ARTIFACT_DIR -Filter *.nupkg -Recurse |
                 % { & "nuget" push $_.FullName -Source $(Source) -ApiKey $(NuGet.ApiKey) -SkipDuplicate | Out-File log.txt -Append }
               


### PR DESCRIPTION
Make sure the log.txt file exists so the logging from the nuget push command can be written there.

Related to https://github.com/arcus-azure/arcus.scripting/issues/388