### PR TITLE
fix: enable integration test for devops variable group description

### DIFF
--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -69,10 +69,11 @@ InModuleScope Arcus.Scripting.DevOps {
             It "Sets the DevOps variable group description with the release name" {
                 # Arrange
                 $variableGroupName = $config.Arcus.DevOps.VariableGroup.Name
+                $variableGroupNameUrlEncoded = $config.Arcus.DevOps.VariableGroup.NameUrlEncoded
                 $variableGroupAuthorization = $config.Arcus.DevOps.VariableGroup.Authorization
                 $projectId = $env:SYSTEM_TEAMPROJECTID                
                 $collectionUri = $env:SYSTEM_COLLECTIONURI
-                $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=/" + $variableGroupName + "?api-version=6.1-preview.2"
+                $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=/" + $variableGroupNameUrlEncoded + "?api-version=6.1-preview.2"
                 $headers = @{ Authorization = "Basic $variableGroupAuthorization" }
 
                 # Act

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -73,7 +73,7 @@ InModuleScope Arcus.Scripting.DevOps {
                 $env:ArmOutputs = "{ ""my-variable"": { ""type"": ""string"", ""value"": ""my-value"" } }"
                 $projectId = $env:SYSTEM_TEAMPROJECTID                
                 $collectionUri = $env:SYSTEM_COLLECTIONURI
-                $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=/" + $variableGroupName + "?api-version=6.0"
+                $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=/" + $variableGroupName + "?api-version=6.1-preview.2"
                 $headers = @{ Authorization = "Basic $variableGroupAuthorization" }
 
                 # Act
@@ -82,7 +82,7 @@ InModuleScope Arcus.Scripting.DevOps {
                 # Assert
                 $getResponse = Invoke-WebRequest -Uri $requestUri -Method Get -Headers $headers
                 $json = ConvertFrom-Json $getResponse.Content
-                $json.description | Should -BeLike "*$env:Build_DefinitionName*$env:Build_BuildNumber*"
+                $json.value[0].description | Should -BeLike "*$env:Build_DefinitionName*$env:Build_BuildNumber*"
             }
         }
     }

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -70,11 +70,14 @@ InModuleScope Arcus.Scripting.DevOps {
                 # Arrange
                 $variableGroupName = $config.Arcus.DevOps.VariableGroup.Name
                 $variableGroupNameUrlEncoded = $config.Arcus.DevOps.VariableGroup.NameUrlEncoded
+                $env:ArmOutputs = "{ ""my-variable"": { ""type"": ""string"", ""value"": ""my-value"" } }"
                 $variableGroupAuthorization = $config.Arcus.DevOps.VariableGroup.Authorization
                 $projectId = $env:SYSTEM_TEAMPROJECTID                
                 $collectionUri = $env:SYSTEM_COLLECTIONURI
                 $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=/" + $variableGroupNameUrlEncoded + "?api-version=6.1-preview.2"
                 $headers = @{ Authorization = "Basic $variableGroupAuthorization" }
+
+                Write-Host $requestUri
 
                 # Act
                 Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName $variableGroupName
@@ -82,8 +85,7 @@ InModuleScope Arcus.Scripting.DevOps {
                 # Assert
                 $getResponse = Invoke-WebRequest -Uri $requestUri -Method Get -Headers $headers
                 $json = ConvertFrom-Json $getResponse.Content
-
-                Write-Host $requestUri
+                                
                 Write-Host $json
                 Write-Host $json.value[0].description
                 Write-Host "*$env:Build_DefinitionName*$env:Build_BuildNumber*"

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -77,19 +77,12 @@ InModuleScope Arcus.Scripting.DevOps {
                 $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=" + $variableGroupNameUrlEncoded + "&api-version=6.1-preview.2"
                 $headers = @{ Authorization = "Basic $variableGroupAuthorization" }
 
-                Write-Host $requestUri
-
                 # Act
                 Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName $variableGroupName
 
                 # Assert
                 $getResponse = Invoke-WebRequest -Uri $requestUri -Method Get -Headers $headers
                 $json = ConvertFrom-Json $getResponse.Content
-                                
-                Write-Host $json
-                Write-Host $json.value[0].description
-                Write-Host "*$env:Build_DefinitionName*$env:Build_BuildNumber*"
-
                 $json.value[0].description | Should -BeLike "*$env:Build_DefinitionName*$env:Build_BuildNumber*"
             }
         }

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -71,6 +71,7 @@ InModuleScope Arcus.Scripting.DevOps {
                 $variableGroupName = $config.Arcus.DevOps.VariableGroup.Name
                 $variableGroupNameUrlEncoded = $config.Arcus.DevOps.VariableGroup.NameUrlEncoded
                 $env:ArmOutputs = "{ ""my-variable"": { ""type"": ""string"", ""value"": ""my-value"" } }"
+                #$variableGroupAuthorization contains a PAT with read access to variable groups, create a new one when it expires
                 $variableGroupAuthorization = $config.Arcus.DevOps.VariableGroup.Authorization
                 $projectId = $env:SYSTEM_TEAMPROJECTID                
                 $collectionUri = $env:SYSTEM_COLLECTIONURI

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -66,14 +66,15 @@ InModuleScope Arcus.Scripting.DevOps {
                     }
                 }
             }
-            It "Sets the DevOps variable group description with the release name" -Skip {
+            It "Sets the DevOps variable group description with the release name" {
                 # Arrange
                 $variableGroupName = $config.Arcus.DevOps.VariableGroup.Name
+                $variableGroupAuthorization = $config.Arcus.DevOps.VariableGroup.Authorization
                 $env:ArmOutputs = "{ ""my-variable"": { ""type"": ""string"", ""value"": ""my-value"" } }"
                 $projectId = $env:SYSTEM_TEAMPROJECTID                
                 $collectionUri = $env:SYSTEM_COLLECTIONURI
                 $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=/" + $variableGroupName + "?api-version=6.0"
-                $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
+                $headers = @{ Authorization = "Basic $variableGroupAuthorization" }
 
                 # Act
                 Set-AzDevOpsArmOutputsToVariableGroup -VariableGroupName $variableGroupName

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -70,7 +70,6 @@ InModuleScope Arcus.Scripting.DevOps {
                 # Arrange
                 $variableGroupName = $config.Arcus.DevOps.VariableGroup.Name
                 $variableGroupAuthorization = $config.Arcus.DevOps.VariableGroup.Authorization
-                $env:ArmOutputs = "{ ""my-variable"": { ""type"": ""string"", ""value"": ""my-value"" } }"
                 $projectId = $env:SYSTEM_TEAMPROJECTID                
                 $collectionUri = $env:SYSTEM_COLLECTIONURI
                 $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=/" + $variableGroupName + "?api-version=6.1-preview.2"

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -81,6 +81,11 @@ InModuleScope Arcus.Scripting.DevOps {
                 # Assert
                 $getResponse = Invoke-WebRequest -Uri $requestUri -Method Get -Headers $headers
                 $json = ConvertFrom-Json $getResponse.Content
+
+                Write-Host $json
+                Write-Host $json.value[0].description
+                Write-Host "*$env:Build_DefinitionName*$env:Build_BuildNumber*"
+
                 $json.value[0].description | Should -BeLike "*$env:Build_DefinitionName*$env:Build_BuildNumber*"
             }
         }

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -74,7 +74,7 @@ InModuleScope Arcus.Scripting.DevOps {
                 $variableGroupAuthorization = $config.Arcus.DevOps.VariableGroup.Authorization
                 $projectId = $env:SYSTEM_TEAMPROJECTID                
                 $collectionUri = $env:SYSTEM_COLLECTIONURI
-                $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=/" + $variableGroupNameUrlEncoded + "?api-version=6.1-preview.2"
+                $requestUri = "$collectionUri" + "$projectId/_apis/distributedtask/variablegroups?groupName=" + $variableGroupNameUrlEncoded + "&api-version=6.1-preview.2"
                 $headers = @{ Authorization = "Basic $variableGroupAuthorization" }
 
                 Write-Host $requestUri

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.DevOps.tests.ps1
@@ -82,6 +82,7 @@ InModuleScope Arcus.Scripting.DevOps {
                 $getResponse = Invoke-WebRequest -Uri $requestUri -Method Get -Headers $headers
                 $json = ConvertFrom-Json $getResponse.Content
 
+                Write-Host $requestUri
                 Write-Host $json
                 Write-Host $json.value[0].description
                 Write-Host "*$env:Build_DefinitionName*$env:Build_BuildNumber*"

--- a/src/Arcus.Scripting.Tests.Integration/appsettings.json
+++ b/src/Arcus.Scripting.Tests.Integration/appsettings.json
@@ -10,6 +10,7 @@
     "DevOps": {
       "VariableGroup": {
         "Name": "#{Arcus.DevOps.VariableGroup.Name}#",
+        "NameUrlEncoded": "#{Arcus.DevOps.VariableGroup.Name.UrlEncoded}#",
         "Authorization": "#{Arcus.DevOps.VariableGroup.Authorization}#"
       }
     },

--- a/src/Arcus.Scripting.Tests.Integration/appsettings.json
+++ b/src/Arcus.Scripting.Tests.Integration/appsettings.json
@@ -9,7 +9,8 @@
     },
     "DevOps": {
       "VariableGroup": {
-        "Name": "#{Arcus.DevOps.VariableGroup.Name}#"
+        "Name": "#{Arcus.DevOps.VariableGroup.Name}#",
+        "Authorization": "#{Arcus.DevOps.VariableGroup.Authorization}#"
       }
     },
     "KeyVault": {


### PR DESCRIPTION
Enable integration test for devops variable group description.
We use a different way to authenticate towards the DevOps API since the `$env:SYSTEM_ACCESSTOKEN` doesn't work for variable groups when triggered by GitHub.

Closes https://github.com/arcus-azure/arcus.scripting/issues/255