### PR TITLE
fix: Conditionally use securestring for `Connect-MgGraph`

### DIFF
--- a/src/Arcus.Scripting.Tests.Integration/Connect-MgGraphFromConfig.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Connect-MgGraphFromConfig.ps1
@@ -17,4 +17,11 @@ $connection = Invoke-RestMethod `
  
 $token = $connection.access_token
 
-Connect-MgGraph -AccessToken $token 
+$targetParameter = (Get-Command Connect-MgGraph).Parameters['AccessToken']
+
+if ($targetParameter.ParameterType -eq [securestring]){
+  Connect-MgGraph -AccessToken ($token |ConvertTo-SecureString -AsPlainText -Force)
+}
+else {
+  Connect-MgGraph -AccessToken $token
+}

--- a/src/Arcus.Scripting.Tests.Integration/Connect-MgGraphFromConfig.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Connect-MgGraphFromConfig.ps1
@@ -19,7 +19,7 @@ $token = $connection.access_token
 
 $targetParameter = (Get-Command Connect-MgGraph).Parameters['AccessToken']
 
-if ($targetParameter.ParameterType -eq [securestring]){
+if ($targetParameter.ParameterType -eq [securestring]) {
   Connect-MgGraph -AccessToken ($token |ConvertTo-SecureString -AsPlainText -Force)
 }
 else {


### PR DESCRIPTION
Conditionally use securestring for `Connect-MgGraph` in integration tests.