### PR TITLE
fix: Filename in powershell gallery push

### DIFF
--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -155,6 +155,7 @@ stages:
               $nugetPackageFiles = Get-ChildItem -Path $env:ARTIFACT_DIR -Filter *.nupkg -Recurse
 
               foreach ($nugetPackageFile in $nugetPackageFiles) {
+                $fullFileName = $nugetPackageFile.FullName
                 % { & "nuget" push $fullFileName -Source $(Source) -ApiKey $(NuGet.ApiKey) -SkipDuplicate }
               }
             displayName: 'Push to PowerShell Gallery'


### PR DESCRIPTION
Fix setting the filename in the powershell gallery push