### PR TITLE
fix: `Backup-AzApiManagementService`: Use managed identity for connection between APIM and Storage Account

### DIFF
--- a/docs/preview/03-Features/powershell/azure-api-management.md
+++ b/docs/preview/03-Features/powershell/azure-api-management.md
@@ -17,16 +17,18 @@ PS> Install-Module -Name Arcus.Scripting.ApiManagement
 
 Backs up an API Management service (with built-in storage context retrieval).
 
-| Parameter                         | Mandatory | Description                                                                                                                                                      |
-| --------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ResourceGroupName`               | yes       | The name of the of resource group under which the API Management deployment exists.                                                                              |
-| `StorageAccountResourceGroupName` | yes       | The name of the resource group under which the storage account exists.                                                                                           |
-| `StorageAccountName`              | yes       | The name of the Storage account for which this cmdlet gets keys.                                                                                                 |
-| `ServiceName`                     | yes       | The name of the API Management deployment that this cmdlet backs up.                                                                                             |
-| `ContainerName`                   | yes       | The name of the container of the blob for the backup. If the container does not exist, this cmdlet creates it.                                                   |
-| `BlobName`                        | no        | The name of the blob for the backup. If the blob does not exist, this cmdlet creates it (default value based on pattern: `{Name}-{yyyy-MM-dd-HH-mm}.apimbackup`. |
-| `PassThru`                        | no        | Indicates that this cmdlet returns the backed up PsApiManagement object, if the operation succeeds.                                                              |
-| `DefaultProfile`                  | no        | The credentials, account, tenant, and subscription used for communication with azure.                                                                            |
+| Parameter                         | Mandatory | Description                                                                                                                                                             |
+| --------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ResourceGroupName`               | yes       | The name of the of resource group under which the API Management deployment exists.                                                                                     |
+| `StorageAccountResourceGroupName` | yes       | The name of the resource group under which the storage account exists.                                                                                                  |
+| `StorageAccountName`              | yes       | The name of the Storage account for which this cmdlet gets keys.                                                                                                        |
+| `ServiceName`                     | yes       | The name of the API Management deployment that this cmdlet backs up.                                                                                                    |
+| `ContainerName`                   | yes       | The name of the container of the blob for the backup. If the container does not exist, this cmdlet creates it.                                                          |
+| `AccessType`                      | yes       | The type of access to be used for the connection from APIM to the storage account, valid values are `SystemAssignedManagedIdentity` and `UserAssignedManagedIdentity`.  |
+| `IdentityClientId`                | no        | The client id of the managed identity to connect from API Management to Storage Account, this is only required when AccessType is set to `UserAssignedManagedIdentity`. |
+| `BlobName`                        | no        | The name of the blob for the backup. If the blob does not exist, this cmdlet creates it (default value based on pattern: `{Name}-{yyyy-MM-dd-HH-mm}.apimbackup`.        |
+| `PassThru`                        | no        | Indicates that this cmdlet returns the backed up PsApiManagement object, if the operation succeeds.                                                                     |
+| `DefaultProfile`                  | no        | The credentials, account, tenant, and subscription used for communication with azure.                                                                                   |
 
 **Example**
 
@@ -38,7 +40,8 @@ PS> Backup-AzApiManagementService `
 -StorageAccountResourceGroupName "my-storage-account-resource-group" `
 -StorageAccountName "my-storage-account" `
 -ServiceName "my-service" `
--ContainerName "my-target-blob-container"
+-ContainerName "my-target-blob-container" `
+-AccessType "SystemAssignedManagedIdentity"
 # New Azure storage context for storage account 'my-storage-account' with storage key created!
 # Azure API management service 'my-service' in resource group 'my-resource-group' is backed-up!
 ```

--- a/docs/preview/03-Features/powershell/azure-storage/azure-storage-table.md
+++ b/docs/preview/03-Features/powershell/azure-storage/azure-storage-table.md
@@ -23,7 +23,7 @@ PS> Install-Module -Name Arcus.Scripting.Storage.Table
 | `StorageAccountName`   | yes       | The name of the Azure Storage Account to add the table to                                                                  |
 | `TableName`            | yes       | The name of the table to add on the Azure Storage Account                                                                  |
 | `Recreate`             | no        | The optional flag to indicate whether or not a possible already existing table should be deleted and re-created            |
-| `RetryIntervalSeconds` | no        | The optional amount of seconds to wait each retry-run when a failure occurs during the re-creating process (default: 5s)  |
+| `RetryIntervalSeconds` | no        | The optional amount of seconds to wait each retry-run when a failure occurs during the re-creating process (default: 10s)  |
 | `MaxRetryCount`        | no        | The optional maximum amount of retry-runs should happen when a failure occurs during the re-creating process (default: 10) |
 
 **Example**
@@ -49,8 +49,8 @@ PS> Create-AzStorageTable `
 -Recreate `
 -RetryIntervalSeconds 3
 # Azure storage table 'products' has been removed from Azure storage account 'admin'
-# Failed to re-create the Azure storage table 'products' in Azure storage account 'admin', retrying in 5 seconds...
-# Failed to re-create the Azure storage table 'products' in Azure storage account 'admin', retrying in 5 seconds...
+# Failed to re-create the Azure storage table 'products' in Azure storage account 'admin', retrying in 3 seconds...
+# Failed to re-create the Azure storage table 'products' in Azure storage account 'admin', retrying in 3 seconds...
 # Azure storage table 'products' created in Azure storage account 'admin'
 ```
 

--- a/src/Arcus.Scripting.ApiManagement/Arcus.Scripting.ApiManagement.psm1
+++ b/src/Arcus.Scripting.ApiManagement/Arcus.Scripting.ApiManagement.psm1
@@ -21,6 +21,12 @@
  .Parameter ContainerName
   The name of the container of the blob for the backup. If the container does not exist, this cmdlet creates it.
 
+ .Parameter AccessType
+  The type of access to be used for the connection from APIM to the storage account, valid values are `SystemAssignedManagedIdentity` and `UserAssignedManagedIdentity`.
+
+ .Parameter IdentityClientId
+  The client id of the managed identity to connect from API Management to Storage Account, this is only required when AccessType is set to `UserAssignedManagedIdentity`.
+
  .Parameter BlobName
   The name of the blob for the backup. If the blob does not exist, this cmdlet creates it. 
   This cmdlet generates a default value based on the following pattern: {Name}-{yyyy-MM-dd-HH-mm}.apimbackup
@@ -36,17 +42,19 @@ function Backup-AzApiManagementService {
         [Parameter(Mandatory = $true)][string] $ResourceGroupName = $(throw "Resource group name is required"),
         [Parameter(Mandatory = $true)][string] $StorageAccountResourceGroupName = $(throw = "Resource group for storage account is required"),
         [Parameter(Mandatory = $true)][string] $StorageAccountName = $(throw "Storage account name is required"),
-        [Parameter(Mandatory = $true)][string] $ServiceName = $(throw "API managgement service name is required"),
+        [Parameter(Mandatory = $true)][string] $ServiceName = $(throw "API management service name is required"),
         [Parameter(Mandatory = $true)][string] $ContainerName = $(throw "Name of the target blob container is required"),
+        [Parameter(Mandatory = $true)][string][ValidateSet('SystemAssignedManagedIdentity', 'UserAssignedManagedIdentity')] $AccessType = $(throw "The access type is required"),
+        [Parameter(Mandatory = $false)][string] $IdentityClientId = "",
         [Parameter(Mandatory = $false)][string] $BlobName = $null,
         [Parameter(Mandatory = $false)][switch] $PassThru = $false,
         [Parameter(Mandatory = $false)][Microsoft.Azure.Commands.Common.Authentication.Abstractions.Core.IAzureContextContainer] $DefaultProfile = $null
     )
 
     if ($PassThru) {
-        . $PSScriptRoot\Scripts\Backup-AzApiManagementService.ps1 -ResourceGroupName $ResourceGroupName -StorageAccountResourceGroupName $StorageAccountResourceGroupName -StorageAccountName $StorageAccountName -ServiceName $ServiceName -ContainerName $ContainerName -BlobName $BlobName -PassThru
+        . $PSScriptRoot\Scripts\Backup-AzApiManagementService.ps1 -ResourceGroupName $ResourceGroupName -StorageAccountResourceGroupName $StorageAccountResourceGroupName -StorageAccountName $StorageAccountName -ServiceName $ServiceName -ContainerName $ContainerName -AccessType $AccessType -IdentityClientId $IdentityClientId -BlobName $BlobName -PassThru
     } else {
-        . $PSScriptRoot\Scripts\Backup-AzApiManagementService.ps1 -ResourceGroupName $ResourceGroupName -StorageAccountResourceGroupName $StorageAccountResourceGroupName -StorageAccountName $StorageAccountName -ServiceName $ServiceName -ContainerName $ContainerName -BlobName $BlobName
+        . $PSScriptRoot\Scripts\Backup-AzApiManagementService.ps1 -ResourceGroupName $ResourceGroupName -StorageAccountResourceGroupName $StorageAccountResourceGroupName -StorageAccountName $StorageAccountName -ServiceName $ServiceName -ContainerName $ContainerName -AccessType $AccessType -IdentityClientId $IdentityClientId -BlobName $BlobName
     }
 }
 

--- a/src/Arcus.Scripting.ApiManagement/Scripts/Backup-AzApiManagementService.ps1
+++ b/src/Arcus.Scripting.ApiManagement/Scripts/Backup-AzApiManagementService.ps1
@@ -31,62 +31,30 @@ if ($storageKeys -eq $null -or $storageKeys.count -eq 0) {
     Write-Verbose "Start backing up Azure API Management instance '$($ServiceName)' in resource group '$($ResourceGroupName)'..."
     if ($BlobName -ne $null -and $BlobName -ne "") {
         if ($PassThru) {
-            if ($DefaultProfile -ne $null) {
-                if ($AccessType -eq 'UserAssignedManagedIdentity') {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -PassThru -DefaultProfile $DefaultProfile
-                } else {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -PassThru -DefaultProfile $DefaultProfile
-                }
+            if ($AccessType -eq 'UserAssignedManagedIdentity') {
+                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -PassThru -DefaultProfile $DefaultProfile
             } else {
-                if ($AccessType -eq 'UserAssignedManagedIdentity') {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -PassThru
-                } else {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -PassThru
-                }
+                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -PassThru -DefaultProfile $DefaultProfile
             }
         } else {
-            if ($DefaultProfile -ne $null) {
-                if ($AccessType -eq 'UserAssignedManagedIdentity') {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -DefaultProfile $DefaultProfile
-                } else {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -DefaultProfile $DefaultProfile
-                }
+            if ($AccessType -eq 'UserAssignedManagedIdentity') {
+                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -DefaultProfile $DefaultProfile
             } else {
-                if ($AccessType -eq 'UserAssignedManagedIdentity') {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName
-                } else {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName
-                }
+                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -DefaultProfile $DefaultProfile
             }
         }
     } else {
         if ($PassThru) {
-            if ($DefaultProfile -ne $null) {
-                if ($AccessType -eq 'UserAssignedManagedIdentity') {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -PassThru -DefaultProfile $DefaultProfile
-                } else {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -PassThru -DefaultProfile $DefaultProfile
-                }
+            if ($AccessType -eq 'UserAssignedManagedIdentity') {
+                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -PassThru -DefaultProfile $DefaultProfile
             } else {
-                if ($AccessType -eq 'UserAssignedManagedIdentity') {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -PassThru
-                } else {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -PassThru
-                }
+                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -PassThru -DefaultProfile $DefaultProfile
             }
         } else {
-            if ($DefaultProfile -ne $null) {
-                if ($AccessType -eq 'UserAssignedManagedIdentity') {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -DefaultProfile $DefaultProfile
-                } else {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -DefaultProfile $DefaultProfile
-                }
+            if ($AccessType -eq 'UserAssignedManagedIdentity') {
+                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -DefaultProfile $DefaultProfile
             } else {
-                if ($AccessType -eq 'UserAssignedManagedIdentity') {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName
-                } else {
-                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName
-                }
+                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -DefaultProfile $DefaultProfile
             }
         }
     }

--- a/src/Arcus.Scripting.ApiManagement/Scripts/Backup-AzApiManagementService.ps1
+++ b/src/Arcus.Scripting.ApiManagement/Scripts/Backup-AzApiManagementService.ps1
@@ -28,36 +28,30 @@ if ($storageKeys -eq $null -or $storageKeys.count -eq 0) {
     $storageContext = New-AzStorageContext -StorageAccountName $StorageAccountName -StorageAccountKey $storageKey.Value
     Write-Host "New Azure storage context for storage account '$($StorageAccountName)' with storage key created!" -ForegroundColor Green
 
-    Write-Verbose "Start backing up Azure API Management instance '$($ServiceName)' in resource group '$($ResourceGroupName)'..."
-    if ($BlobName -ne $null -and $BlobName -ne "") {
-        if ($PassThru) {
-            if ($AccessType -eq 'UserAssignedManagedIdentity') {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -PassThru -DefaultProfile $DefaultProfile
-            } else {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -PassThru -DefaultProfile $DefaultProfile
-            }
-        } else {
-            if ($AccessType -eq 'UserAssignedManagedIdentity') {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -DefaultProfile $DefaultProfile
-            } else {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -DefaultProfile $DefaultProfile
-            }
-        }
-    } else {
-        if ($PassThru) {
-            if ($AccessType -eq 'UserAssignedManagedIdentity') {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -PassThru -DefaultProfile $DefaultProfile
-            } else {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -PassThru -DefaultProfile $DefaultProfile
-            }
-        } else {
-            if ($AccessType -eq 'UserAssignedManagedIdentity') {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -DefaultProfile $DefaultProfile
-            } else {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -DefaultProfile $DefaultProfile
-            }
-        }
+    $backupArguments = @{
+      ResourceGroupName = $ResourceGroupName
+      Name = $ServiceName
+      AccessType = $AccessType
+      StorageContext = $storageContext
+      TargetContainerName = $ContainerName
+      DefaultProfile = $DefaultProfile
     }
 
+    if ($PassThru) {
+      $backupArguments.PassThru = $true
+    } else {
+      $backupArguments.PassThru = $false
+    }
+
+    if ($AccessType -eq 'UserAssignedManagedIdentity') {
+      $backupArguments.IdentityClientId = $IdentityClientId
+    }
+
+    if ($BlobName -ne $null -and $BlobName -ne "") {
+      $backupArguments.TargetBlobName = $BlobName
+    }
+
+    Write-Verbose "Start backing up Azure API Management instance '$($ServiceName)' in resource group '$($ResourceGroupName)'..."
+    Backup-AzApiManagement @backupArguments
     Write-Host "Azure API Management instance '$($ServiceName)' in resource group '$($ResourceGroupName)' is backed-up!" -ForegroundColor Green
 }

--- a/src/Arcus.Scripting.ApiManagement/Scripts/Backup-AzApiManagementService.ps1
+++ b/src/Arcus.Scripting.ApiManagement/Scripts/Backup-AzApiManagementService.ps1
@@ -2,12 +2,18 @@ param(
     [Parameter(Mandatory = $true)][string] $ResourceGroupName = $(throw "Resource group name is required"),
     [Parameter(Mandatory = $true)][string] $StorageAccountResourceGroupName = $(throw = "Resource group for storage account is required"),
     [Parameter(Mandatory = $true)][string] $StorageAccountName = $(throw "Storage account name is required"),
-    [Parameter(Mandatory = $true)][string] $ServiceName = $(throw "API managgement service name is required"),
+    [Parameter(Mandatory = $true)][string] $ServiceName = $(throw "API management service name is required"),
     [Parameter(Mandatory = $true)][string] $ContainerName = $(throw "Name of the target blob container is required"),
-    [Parameter(Mandatory = $false)][string]  $BlobName = $null,
+    [Parameter(Mandatory = $true)][string][ValidateSet('SystemAssignedManagedIdentity', 'UserAssignedManagedIdentity')] $AccessType = $(throw "The access type is required"),
+    [Parameter(Mandatory = $false)][string] $IdentityClientId = "",
+    [Parameter(Mandatory = $false)][string] $BlobName = $null,
     [Parameter(Mandatory = $false)][switch] $PassThru = $false,
     [Parameter(Mandatory = $false)][Microsoft.Azure.Commands.Common.Authentication.Abstractions.Core.IAzureContextContainer] $DefaultProfile = $null
 )
+
+if ($AccessType -eq 'UserAssignedManagedIdentity' -and $IdentityClientId -eq "") {
+    throw "Id of the user assigned managed identity is required if AccessType is set to 'UserAssignedManagedIdentity'"
+}
 
 Write-Verbose "Getting Azure storage account key for storage account '$($StorageAccountName)' in resource group '$($StorageAccountResourceGroupName)'..."
 $storageKeys = Get-AzStorageAccountKey -ResourceGroupName $StorageAccountResourceGroupName -StorageAccountName $StorageAccountName
@@ -23,32 +29,64 @@ if ($storageKeys -eq $null -or $storageKeys.count -eq 0) {
     Write-Host "New Azure storage context for storage account '$($StorageAccountName)' with storage key created!" -ForegroundColor Green
 
     Write-Verbose "Start backing up Azure API Management instance '$($ServiceName)' in resource group '$($ResourceGroupName)'..."
-    if ($BlobName -ne $null) {
+    if ($BlobName -ne $null -and $BlobName -ne "") {
         if ($PassThru) {
             if ($DefaultProfile -ne $null) {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -PassThru -DefaultProfile $DefaultProfile
+                if ($AccessType -eq 'UserAssignedManagedIdentity') {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -PassThru -DefaultProfile $DefaultProfile
+                } else {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -PassThru -DefaultProfile $DefaultProfile
+                }
             } else {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -PassThru
+                if ($AccessType -eq 'UserAssignedManagedIdentity') {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -PassThru
+                } else {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -PassThru
+                }
             }
         } else {
             if ($DefaultProfile -ne $null) {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -DefaultProfile $DefaultProfile
+                if ($AccessType -eq 'UserAssignedManagedIdentity') {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -DefaultProfile $DefaultProfile
+                } else {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName -DefaultProfile $DefaultProfile
+                }
             } else {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName
+                if ($AccessType -eq 'UserAssignedManagedIdentity') {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName
+                } else {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -TargetBlobName $BlobName
+                }
             }
         }
     } else {
         if ($PassThru) {
             if ($DefaultProfile -ne $null) {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -StorageContext $storageContext -TargetContainerName $ContainerName -PassThru -DefaultProfile $DefaultProfile
+                if ($AccessType -eq 'UserAssignedManagedIdentity') {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -PassThru -DefaultProfile $DefaultProfile
+                } else {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -PassThru -DefaultProfile $DefaultProfile
+                }
             } else {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -StorageContext $storageContext -TargetContainerName $ContainerName -PassThru
+                if ($AccessType -eq 'UserAssignedManagedIdentity') {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -PassThru
+                } else {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -PassThru
+                }
             }
         } else {
             if ($DefaultProfile -ne $null) {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -StorageContext $storageContext -TargetContainerName $ContainerName -DefaultProfile $DefaultProfile
+                if ($AccessType -eq 'UserAssignedManagedIdentity') {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName -DefaultProfile $DefaultProfile
+                } else {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName -DefaultProfile $DefaultProfile
+                }
             } else {
-                Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -StorageContext $storageContext -TargetContainerName $ContainerName
+                if ($AccessType -eq 'UserAssignedManagedIdentity') {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -IdentityClientId $IdentityClientId -StorageContext $storageContext -TargetContainerName $ContainerName
+                } else {
+                    Backup-AzApiManagement -ResourceGroupName $ResourceGroupName -Name $ServiceName -AccessType $AccessType -StorageContext $storageContext -TargetContainerName $ContainerName
+                }
             }
         }
     }

--- a/src/Arcus.Scripting.Storage.Table/Arcus.Scripting.Storage.Table.psm1
+++ b/src/Arcus.Scripting.Storage.Table/Arcus.Scripting.Storage.Table.psm1
@@ -29,7 +29,7 @@ function Create-AzStorageTable {
         [Parameter(Mandatory = $true)][string] $StorageAccountName = $(throw "Name of Azure storage account is required"),
         [Parameter(Mandatory = $true)][string] $TableName = $(throw "Name of Azure table is required"),
         [Parameter()][switch] $Recreate = $false,
-        [Parameter(Mandatory = $false)][int] $RetryIntervalSeconds = 5,
+        [Parameter(Mandatory = $false)][int] $RetryIntervalSeconds = 10,
         [Parameter(Mandatory = $false)][int] $MaxRetryCount = 10
     )
 

--- a/src/Arcus.Scripting.Storage.Table/Scripts/Create-AzTableStorageAccountTable.ps1
+++ b/src/Arcus.Scripting.Storage.Table/Scripts/Create-AzTableStorageAccountTable.ps1
@@ -47,6 +47,7 @@ if ($TableName -in $tables.Name) {
     if ($Recreate) {
         Write-Verbose "Deleting existing Azure storage table '$TableName' in the Azure storage account '$StorageAccountName'..."
         $isRemoved = Remove-AzStorageTable -Name $TableName -Context $storageAccount.Context -Force
+        Start-Sleep -Seconds 40
         if ($isRemoved -eq $false) {
             throw "Could not successfully remove Azure storage table '$TableName' in the Azure storage account '$StorageAccountName'"
         }

--- a/src/Arcus.Scripting.Storage.Table/Scripts/Create-AzTableStorageAccountTable.ps1
+++ b/src/Arcus.Scripting.Storage.Table/Scripts/Create-AzTableStorageAccountTable.ps1
@@ -3,7 +3,7 @@ param(
     [Parameter(Mandatory = $true)][string] $StorageAccountName = $(throw "Name of Azure storage account is required"),
     [Parameter(Mandatory = $true)][string] $TableName = $(throw "Name of Azure table is required"),
     [Parameter()][switch] $Recreate = $false,
-    [Parameter(Mandatory = $false)][int] $RetryIntervalSeconds = 5,
+    [Parameter(Mandatory = $false)][int] $RetryIntervalSeconds = 10,
     [Parameter(Mandatory = $false)][int] $MaxRetryCount = 10
 )
 
@@ -47,7 +47,6 @@ if ($TableName -in $tables.Name) {
     if ($Recreate) {
         Write-Verbose "Deleting existing Azure storage table '$TableName' in the Azure storage account '$StorageAccountName'..."
         $isRemoved = Remove-AzStorageTable -Name $TableName -Context $storageAccount.Context -Force
-        Start-Sleep -Seconds 40
         if ($isRemoved -eq $false) {
             throw "Could not successfully remove Azure storage table '$TableName' in the Azure storage account '$StorageAccountName'"
         }

--- a/src/Arcus.Scripting.Storage.Table/Scripts/Create-AzTableStorageAccountTable.ps1
+++ b/src/Arcus.Scripting.Storage.Table/Scripts/Create-AzTableStorageAccountTable.ps1
@@ -55,7 +55,7 @@ if ($TableName -in $tables.Name) {
         
         $retryIndex = 1
         while (-not (Try-CreateTable -StorageAccount $storageAccount -TableName $TableName -RetryIndex $retryIndex)) {
-            Write-Warning "Failed to re-create the Azure storage table '$TableName' in Azure storage account '$StorageAccountName', retrying in 5 seconds..."
+            Write-Warning "Failed to re-create the Azure storage table '$TableName' in Azure storage account '$StorageAccountName', retrying in '$RetryIntervalSeconds' seconds..."
             $retryIndex = $retryIndex + 1
             Start-Sleep -Seconds $RetryIntervalSeconds
         }

--- a/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.Security.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Integration/Arcus.Scripting.Security.tests.ps1
@@ -57,9 +57,13 @@ InModuleScope Arcus.Scripting.Security {
                     -LockLevel CanNotDelete `
                     -Force
 
+                Start-Sleep -Seconds 10
+
                 try {
                     # Act
                     Remove-AzResourceGroupLocks -ResourceGroupName $targetResourceGroupName -LockName $lockName
+
+                    Start-Sleep -Seconds 10
                 
                     # Assert
                     $locks = Get-AzResourceLock -ResourceGroupName $targetResourceGroupName
@@ -89,9 +93,13 @@ InModuleScope Arcus.Scripting.Security {
                     -LockLevel CanNotDelete `
                     -Force
 
+                Start-Sleep -Seconds 10
+
                 try {
                     # Act
                     Remove-AzResourceGroupLocks -ResourceGroupName $targetResourceGroupName
+
+                    Start-Sleep -Seconds 10
                 
                     # Assert
                     $locks = Get-AzResourceLock -ResourceGroupName $targetResourceGroupName

--- a/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.ApiManagement.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.ApiManagement.tests.ps1
@@ -21,6 +21,7 @@ InModuleScope Arcus.Scripting.ApiManagement {
                 $targetContainerName = "backup-storage"
                 $storageKeyValue = "my-storage-key"
                 $storageKey = New-Object -TypeName Microsoft.Azure.Management.Storage.Models.StorageAccountKey -ArgumentList @($null, $storageKeyValue, $null)
+                $accessType = 'SystemAssignedManagedIdentity'
 
                 Mock Get-AzStorageAccountKey {
                     $ResourceGroupName | Should -Be $storageAccountResourceGroup
@@ -33,6 +34,7 @@ InModuleScope Arcus.Scripting.ApiManagement {
                 Mock Backup-AzApiManagement {
                     $ResourceGroupName | Should -Be $resourceGroup
                     $Name | Should -Be $serviceName
+                    $AccessType | Should -Be $accessType
                     $StorageContext | Should -be $expectedStorageContext
                     $TargetContainerName | Should -Be $targetContainerName
                     $TargetBlobName | Should -BeNullOrEmpty 
@@ -40,7 +42,7 @@ InModuleScope Arcus.Scripting.ApiManagement {
                     $DefaultProfile | Should -Be $null }
 
                 # Act
-                Backup-AzApiManagementService -ResourceGroupName $resourceGroup -StorageAccountResourceGroup $storageAccountResourceGroup -StorageAccountName $expectedStorageAccountName -ServiceName $serviceName -ContainerName $targetContainerName
+                Backup-AzApiManagementService -ResourceGroupName $resourceGroup -StorageAccountResourceGroup $storageAccountResourceGroup -StorageAccountName $expectedStorageAccountName -ServiceName $serviceName -ContainerName $targetContainerName -AccessType $accessType
 
                 # Assert
                 Assert-VerifiableMock
@@ -58,7 +60,8 @@ InModuleScope Arcus.Scripting.ApiManagement {
                 $targetBlobName = "backup-storage-blob"
                 $storageKeyValue = "my-storage-key"
                 $storageKey = New-Object -TypeName Microsoft.Azure.Management.Storage.Models.StorageAccountKey -ArgumentList @($null, $storageKeyValue, $null)
-                
+                $accessType = 'SystemAssignedManagedIdentity'
+
                 Mock Get-AzStorageAccountKey {
                     $ResourceGroupName | Should -Be $storageAccountResourceGroup
                     $StorageAccountName | Should -Be $expectedStorageAccountName
@@ -70,6 +73,7 @@ InModuleScope Arcus.Scripting.ApiManagement {
                 Mock Backup-AzApiManagement {
                     $ResourceGroupName | Should -Be $resourceGroup
                     $Name | Should -Be $serviceName
+                    $AccessType | Should -Be $accessType
                     $StorageContext | Should -be $expectedStorageContext
                     $TargetContainerName | Should -Be $targetContainerName
                     $TargetBlobName | Should -Be $targetBlobName
@@ -77,7 +81,7 @@ InModuleScope Arcus.Scripting.ApiManagement {
                     $DefaultProfile | Should -Be $null }
 
                 # Act
-                Backup-AzApiManagementService -ResourceGroupName $resourceGroup -StorageAccountResourceGroup $storageAccountResourceGroup -StorageAccountName $expectedStorageAccountName -ServiceName $serviceName -ContainerName $targetContainerName -BlobName $targetBlobName
+                Backup-AzApiManagementService -ResourceGroupName $resourceGroup -StorageAccountResourceGroup $storageAccountResourceGroup -StorageAccountName $expectedStorageAccountName -ServiceName $serviceName -ContainerName $targetContainerName -BlobName $targetBlobName -AccessType $accessType
 
                 # Assert
                 Assert-VerifiableMock
@@ -94,7 +98,8 @@ InModuleScope Arcus.Scripting.ApiManagement {
                 $targetContainerName = "backup-storage"
                 $storageKeyValue = "my-storage-key"
                 $storageKey = New-Object -TypeName Microsoft.Azure.Management.Storage.Models.StorageAccountKey -ArgumentList @($null, $storageKeyValue, $null)
-                
+                $accessType = 'SystemAssignedManagedIdentity'
+
                 Mock Get-AzStorageAccountKey {
                     $ResourceGroupName | Should -Be $storageAccountResourceGroup
                     $StorageAccountName | Should -Be $expectedStorageAccountName
@@ -106,6 +111,7 @@ InModuleScope Arcus.Scripting.ApiManagement {
                 Mock Backup-AzApiManagement {
                     $ResourceGroupName | Should -Be $resourceGroup
                     $Name | Should -Be $serviceName
+                    $AccessType | Should -Be $accessType
                     $StorageContext | Should -be $expectedStorageContext
                     $TargetContainerName | Should -Be $targetContainerName
                     $TargetBlobName | Should -BeNullOrEmpty 
@@ -113,7 +119,7 @@ InModuleScope Arcus.Scripting.ApiManagement {
                     $DefaultProfile | Should -Be $null }
 
                 # Act
-                Backup-AzApiManagementService -ResourceGroupName $resourceGroup -StorageAccountResourceGroup $storageAccountResourceGroup -StorageAccountName $expectedStorageAccountName -ServiceName $serviceName -ContainerName $targetContainerName -PassThru
+                Backup-AzApiManagementService -ResourceGroupName $resourceGroup -StorageAccountResourceGroup $storageAccountResourceGroup -StorageAccountName $expectedStorageAccountName -ServiceName $serviceName -ContainerName $targetContainerName -AccessType $accessType -PassThru
 
                 # Assert
                 Assert-VerifiableMock
@@ -131,6 +137,7 @@ InModuleScope Arcus.Scripting.ApiManagement {
                 $storageKeyValue = "my-storage-key"
                 $storageKey = New-Object -TypeName Microsoft.Azure.Management.Storage.Models.StorageAccountKey -ArgumentList @($null, $storageKeyValue, $null)
                 $defaultProfile = New-Object -TypeName Microsoft.Azure.Commands.Common.Authentication.Models.AzureRmProfile
+                $accessType = 'SystemAssignedManagedIdentity'
 
                 Mock Get-AzStorageAccountKey {
                     $ResourceGroupName | Should -Be $storageAccountResourceGroup
@@ -143,6 +150,7 @@ InModuleScope Arcus.Scripting.ApiManagement {
                 Mock Backup-AzApiManagement {
                     $ResourceGroupName | Should -Be $resourceGroup
                     $Name | Should -Be $serviceName
+                    $AccessType | Should -Be $accessType
                     $StorageContext | Should -be $expectedStorageContext
                     $TargetContainerName | Should -Be $targetContainerName
                     $TargetBlobName | Should -BeNullOrEmpty 
@@ -150,7 +158,47 @@ InModuleScope Arcus.Scripting.ApiManagement {
                     $DefaultProfile | Should -Be $defaultProfile }
 
                 # Act
-                Backup-AzApiManagementService -ResourceGroupName $resourceGroup -StorageAccountResourceGroup $storageAccountResourceGroup -StorageAccountName $expectedStorageAccountName -ServiceName $serviceName -ContainerName $targetContainerName -PassThru -DefaultProfile $defaultProfile
+                Backup-AzApiManagementService -ResourceGroupName $resourceGroup -StorageAccountResourceGroup $storageAccountResourceGroup -StorageAccountName $expectedStorageAccountName -ServiceName $serviceName -ContainerName $targetContainerName -AccessType $accessType -PassThru -DefaultProfile $defaultProfile
+
+                # Assert
+                Assert-VerifiableMock
+                Assert-MockCalled Get-AzStorageAccountKey -Times 1
+                Assert-MockCalled New-AzStorageContext -Times 1
+                Assert-MockCalled Backup-AzApiManagement -Times 1
+            }
+            It "Backs up API management with User Assigned Managed Identity" {
+                # Arrange
+                $resourceGroup = "shopping"
+                $storageAccountResourceGroup = "stock"
+                $expectedStorageAccountName = "shopping-storage"
+                $serviceName = "shopping-API-management"
+                $targetContainerName = "backup-storage"
+                $storageKeyValue = "my-storage-key"
+                $storageKey = New-Object -TypeName Microsoft.Azure.Management.Storage.Models.StorageAccountKey -ArgumentList @($null, $storageKeyValue, $null)
+                $accessType = 'UserAssignedManagedIdentity'
+                $identityClientId = 'someidentityid'
+
+                Mock Get-AzStorageAccountKey {
+                    $ResourceGroupName | Should -Be $storageAccountResourceGroup
+                    $StorageAccountName | Should -Be $expectedStorageAccountName
+                    return $storageKey }
+                Mock New-AzStorageContext { 
+                    $StorageAccountName | Should -Be $StorageAccountName
+                    $StorageAccountKey | Should -Be $storageKeyValue
+                    return $expectedStorageContext }
+                Mock Backup-AzApiManagement {
+                    $ResourceGroupName | Should -Be $resourceGroup
+                    $Name | Should -Be $serviceName
+                    $AccessType | Should -Be $accessType
+                    $IdentityClientId | Should -Be $identityClientId
+                    $StorageContext | Should -be $expectedStorageContext
+                    $TargetContainerName | Should -Be $targetContainerName
+                    $TargetBlobName | Should -BeNullOrEmpty 
+                    $PassThru | Should -Be $false
+                    $DefaultProfile | Should -Be $null }
+
+                # Act
+                Backup-AzApiManagementService -ResourceGroupName $resourceGroup -StorageAccountResourceGroup $storageAccountResourceGroup -StorageAccountName $expectedStorageAccountName -ServiceName $serviceName -ContainerName $targetContainerName -AccessType $accessType -IdentityClientId $identityClientId
 
                 # Assert
                 Assert-VerifiableMock


### PR DESCRIPTION
Closes https://github.com/arcus-azure/arcus.scripting/issues/426

Also had to add a delay to `Create-AzTableStorageAccountTable.ps1` as this was failing the integration tests and documentation states that a remove action can take 40 seconds: https://learn.microsoft.com/en-us/rest/api/storageservices/Delete-Table?redirectedfrom=MSDN#remarks
> Note that deleting a table is likely to take at least 40 seconds to complete. If you attempt an operation against the table while it's being deleted, the service returns status code 409 (Conflict). 