### PR TITLE
fix: az devops takes heading space as part of value

### DIFF
--- a/src/Arcus.Scripting.DevOps/Arcus.Scripting.DevOps.psm1
+++ b/src/Arcus.Scripting.DevOps/Arcus.Scripting.DevOps.psm1
@@ -19,9 +19,9 @@ function Set-AzDevOpsVariable {
     )
     
     if ($AsSecret) {
-        Write-Host "##vso[task.setvariable variable=$Name;issecret=true] $Value"
+        Write-Host "##vso[task.setvariable variable=$Name;issecret=true]$Value"
     } else {
-        Write-Host "##vso[task.setvariable variable=$Name] $Value"
+        Write-Host "##vso[task.setvariable variable=$Name]$Value"
     }
 }
 

--- a/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.DevOps.tests.ps1
+++ b/src/Arcus.Scripting.Tests.Unit/Arcus.Scripting.DevOps.tests.ps1
@@ -5,7 +5,7 @@ InModuleScope Arcus.Scripting.DevOps {
         Context "Setting ARM outputs to Azure DevOps variable group" {
             It "Setting DevOps variable should write to host" {
                 # Arrange
-                Mock Write-Host { $Object | Should -Be "##vso[task.setvariable variable=test] value" } -Verifiable
+                Mock Write-Host { $Object | Should -Be "##vso[task.setvariable variable=test]value" } -Verifiable
                 
                 # Act
                 Set-AzDevOpsVariable "test" "value"
@@ -15,7 +15,7 @@ InModuleScope Arcus.Scripting.DevOps {
             }
             It "Setting DevOps variable as secret should write to host" {
                 # Arrange
-                Mock Write-Host { $Object | Should -Be "##vso[task.setvariable variable=test;issecret=true] value" } -Verifiable
+                Mock Write-Host { $Object | Should -Be "##vso[task.setvariable variable=test;issecret=true]value" } -Verifiable
                 
                 # Act
                 Set-AzDevOpsVariable "test" "value" -AsSecret


### PR DESCRIPTION
The heading whitespace is considered a part of the value when setting a variable in Azure DevOps. This PR removes that.