### PR TITLE
feat: Configurable database-version table-name

### DIFF
--- a/src/Arcus.Scripting.Sql/Arcus.Scripting.Sql.psm1
+++ b/src/Arcus.Scripting.Sql/Arcus.Scripting.Sql.psm1
@@ -101,7 +101,7 @@ function Invoke-AzSqlDatabaseMigration {
         [Parameter(Mandatory = $false)][string] $DatabaseVersionTable = "DatabaseVersion"
     )
 
-    . $PSScriptRoot\Scripts\Invoke-AzSqlDatabaseMigration.ps1 -ServerName $ServerName -DatabaseName $DatabaseName -UserName $UserName -Password $Password -TrustServerCertificate $TrustServerCertificate -ScriptsFolder $ScriptsFolder -ScriptsFileFilter $ScriptsFileFilter -DatabaseSchema $DatabaseSchema
+    . $PSScriptRoot\Scripts\Invoke-AzSqlDatabaseMigration.ps1 -ServerName $ServerName -DatabaseName $DatabaseName -UserName $UserName -Password $Password -TrustServerCertificate $TrustServerCertificate -ScriptsFolder $ScriptsFolder -ScriptsFileFilter $ScriptsFileFilter -DatabaseSchema $DatabaseSchema -DatabaseVersionTable $DatabaseVersionTable
 }
 
 Export-ModuleMember -Function Invoke-AzSqlDatabaseMigration

--- a/src/Arcus.Scripting.Sql/Arcus.Scripting.Sql.psm1
+++ b/src/Arcus.Scripting.Sql/Arcus.Scripting.Sql.psm1
@@ -84,6 +84,9 @@ class DatabaseVersion : System.IComparable {
 
  .Parameter DatabaseSchema
   The database schema to use when running SQL commands on the target database.
+
+ .Parameter DatabaseVersionTable
+  The name of the table in the database that keeps track of the applied database-migrations.
 #>
 function Invoke-AzSqlDatabaseMigration {
     param(
@@ -94,7 +97,8 @@ function Invoke-AzSqlDatabaseMigration {
         [Parameter(Mandatory = $false)][switch] $TrustServerCertificate,
         [Parameter(Mandatory = $false)][string] $ScriptsFolder = "$PSScriptRoot/sqlScripts",
         [Parameter(Mandatory = $false)][string] $ScriptsFileFilter = "*.sql",
-        [Parameter(Mandatory = $false)][string] $DatabaseSchema = "dbo"
+        [Parameter(Mandatory = $false)][string] $DatabaseSchema = "dbo",
+        [Parameter(Mandatory = $false)][string] $DatabaseVersionTable = "DatabaseVersion"
     )
 
     . $PSScriptRoot\Scripts\Invoke-AzSqlDatabaseMigration.ps1 -ServerName $ServerName -DatabaseName $DatabaseName -UserName $UserName -Password $Password -TrustServerCertificate $TrustServerCertificate -ScriptsFolder $ScriptsFolder -ScriptsFileFilter $ScriptsFileFilter -DatabaseSchema $DatabaseSchema


### PR DESCRIPTION
Introduced a new parameter `DatabaseVersionTable` which has a default value ('DatabaseVersion').
This parameter allows to specify the name of the table that must be used to keep track of applied DB migrations.

Closes #448 