### PR TITLE
chore(docs): auto-trigger new feature docs version via release pipeline

### DIFF
--- a/.github/workflows/bump-docs-version.yml
+++ b/.github/workflows/bump-docs-version.yml
@@ -1,0 +1,45 @@
+name: Bump new docs version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Specify the new version to bump (e.g. v1.1.0)'
+        required: true
+
+jobs:
+  generate-new-version:
+    runs-on: ubuntu-latest
+  
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+
+      - name: Generate new version
+        run: |
+          cd docs
+          npm install
+          npm run docusaurus docs:version ${{ github.event.inputs.version }}
+
+      - name: Check for changes
+        run: |
+          if git diff --quiet; then
+            echo "No changes detected."
+            exit 0
+          fi
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: "docs(${{ github.event.inputs.version }})/bump-docs-version"
+          title: "docs(${{ github.event.inputs.version }}): bump new docs version"
+          body: "This automatically generated PR bumps the docs version to ${{ github.event.inputs.version }}."
+          commit-message: "docs(${{ github.event.inputs.version }}): bump new docs version"
+          delete-branch: true

--- a/build/psgallery-release.yml
+++ b/build/psgallery-release.yml
@@ -56,6 +56,7 @@ resources:
       endpoint: arcus-azure
 
 variables:
+  - group: 'GitHub Configuration'
   - group: 'Build Configuration'
   - group: 'Arcus Scripting - Integration Testing'
   - group: 'Arcus.Scripting - Releasing PS Gallery'
@@ -205,3 +206,6 @@ stages:
             displayName: 'Push to PowerShell Gallery'
             env:
               ARTIFACT_DIR: '$(Build.ArtifactStagingDirectory)'
+          - template: templates/trigger-bump-docs-version.yml
+            parameters:
+              gitHubToken: $(GITHUB_TOKEN)

--- a/build/templates/trigger-bump-docs-version.yml
+++ b/build/templates/trigger-bump-docs-version.yml
@@ -16,5 +16,5 @@ steps:
       }
     displayName: 'Trigger new feature docs version PR'
     env:
-      GITHUB_TOKEN: $(gitHubToken)
+      GITHUB_TOKEN: ${{ parameters.gitHubToken }}
       VERSION: $(Build.BuildNumber)

--- a/build/templates/trigger-bump-docs-version.yml
+++ b/build/templates/trigger-bump-docs-version.yml
@@ -1,0 +1,20 @@
+parameters:
+  gitHubToken: ''
+
+steps:
+  - script: sudo apt install gh
+    displayName: 'Install GitHub CLI'
+  - powershell: |
+      gh auth login --with-token $(GITHUB_TOKEN)
+      gh repo view
+
+      if ($(VERSION) -notmatch '-' -and $(VERSION) -match '^v[0-9]+\.[0-9]+\.0$') {
+        gh workflow run bump-docs-version.yml `
+          --repo arcus-azure/arcus.testing `
+          --ref main `
+          --field version=$(VERSION)
+      }
+    displayName: 'Trigger new feature docs version PR'
+    env:
+      GITHUB_TOKEN: $(GITHUB_TOKEN)
+      VERSION: $(Build.BuildNumber)

--- a/build/templates/trigger-bump-docs-version.yml
+++ b/build/templates/trigger-bump-docs-version.yml
@@ -16,5 +16,5 @@ steps:
       }
     displayName: 'Trigger new feature docs version PR'
     env:
-      GITHUB_TOKEN: $(GITHUB_TOKEN)
+      GITHUB_TOKEN: $(gitHubToken)
       VERSION: $(Build.BuildNumber)

--- a/build/templates/trigger-bump-docs-version.yml
+++ b/build/templates/trigger-bump-docs-version.yml
@@ -8,13 +8,12 @@ steps:
       gh auth login --with-token $(GITHUB_TOKEN)
       gh repo view
 
-      if ($(VERSION) -notmatch '-' -and $(VERSION) -match '^v[0-9]+\.[0-9]+\.0$') {
+      if ($env:VERSION -notmatch '-' -and $env:VERSION -match '^v[0-9]+\.[0-9]+\.0$') {
         gh workflow run bump-docs-version.yml `
           --repo arcus-azure/arcus.testing `
           --ref main `
-          --field version=$(VERSION)
+          --field version=$env:VERSION
       }
     displayName: 'Trigger new feature docs version PR'
     env:
-      GITHUB_TOKEN: ${{ parameters.gitHubToken }}
-      VERSION: $(Build.BuildNumber)
+      VERSION: v$(Build.BuildNumber)


### PR DESCRIPTION
* Adds a GitHub workflow `bump-docs-version.yml` that runs the necessary steps described in the `/docs/README.md` to bump a new feature documentation version and proposes these changes in a PR.
* Adds a step in the Azure DevOps PowerShell Gallery release pipeline that triggers the workflow described above with the user-provided package version.

Together, they auto-trigger a new feature docs PR with the package version that is provided via Azure DevOps, making the release process more automated.